### PR TITLE
Update derivative dependency to resolve Clippy's warnings.

### DIFF
--- a/legion_core/Cargo.toml
+++ b/legion_core/Cargo.toml
@@ -25,7 +25,7 @@ itertools = "0.8"
 rayon = { version = "1.2", optional = true }
 crossbeam-queue = { version = "0.2.0", optional = true }
 crossbeam-channel = "0.4.0"
-derivative = "1"
+derivative = "2.1.1"
 smallvec = "1.2"
 tracing = "0.1"
 metrics = { version = "0.12", optional = true }


### PR DESCRIPTION
Derivative fixed this issue last version 2.1.1. So updating the version should fix all the warnings in the CI.