### PR TITLE
allow `system` macro to use a local module for legion behind a feature instead of the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ crossbeam-events = ["crossbeam-channel"]
 codegen = ["legion_codegen"]
 stdweb = ["uuid/stdweb"]
 wasm-bindgen = ["uuid/wasm-bindgen"]
+reexport = ["legion_codegen", "legion_codegen/reexport"]
 
 [dependencies]
 legion_codegen = { path = "codegen", version = "0.3", optional = true }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -18,3 +18,7 @@ quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"
 thiserror = "1.0"
+
+[features]
+default = []
+reexport = []


### PR DESCRIPTION
fixes #178 

This is due to all paths to `legion` in the macro starting with `::` which means that `legion` has to be a crate and not a module.

I found this issue when playing with Amethyst where the `system` macro doesn't work with the [following error](https://github.com/amethyst/amethyst/pull/2483#issuecomment-689036935):
```
error[E0432]: unresolved import `legion`
  --> examples/pong_tutorial_03/systems/paddle.rs:34:1
   |
34 | #[system]
   | ^^^^^^^^^ help: a similar path exists: `amethyst_core::legion`
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `legion` in `{{root}}`
  --> examples/pong_tutorial_03/systems/paddle.rs:34:1
   |
34 | #[system]
   | ^^^^^^^^^ could not find `legion` in `{{root}}`
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `legion` in `{{root}}`
  --> examples/pong_tutorial_03/systems/paddle.rs:34:1
   |
34 | #[system]
   | ^^^^^^^^^ not found in `legion::systems`
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing one of these items
   |
1  | use amethyst::ecs::SystemBuilder;
   |
1  | use amethyst_core::ecs::SystemBuilder;
   |
1  | use crate::SystemBuilder;
   |
```

If I add `legion` as a direct dependency, it works, but it's not ideal because it means everyone using `amethyst` with `legion` would always need to keep both in sync.

I added a feature `reexport` that, when enabled, will switch the path prefix from `::` to `self::`, which means I can now use a re-exported `legion` module