### PR TITLE
Improve WASM feature docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ Legion provides a few feature flags:
 
 ## WASM
 
-Legion runs with parallelism on by default, which is not currently supported by Web Assembly as it runs single-threaded. Therefore, to build for WASM, ensure you set `default-features = false` in Cargo.toml. Additionally, you must enable either the `stdweb` or `wasm-bindgen` features, which will be proxied through to the `uuid` crate. See the [uuid crate](https://github.com/uuid-rs/uuid#dependencies) for more information.
+Legion runs with parallelism on by default, which is not currently supported by Web Assembly as it runs single-threaded. Therefore, to build for WASM, ensure you set `default-features = false` in Cargo.toml. Additionally, if you want to use the `serialize` feature, you must enable either the `stdweb` or `wasm-bindgen` features, which will be proxied through to the `uuid` crate. See the [uuid crate](https://github.com/uuid-rs/uuid#dependencies) for more information.
 
 ```toml
 legion = { version = "*", default-features = false, features = ["stdweb"] }


### PR DESCRIPTION
I was puzzled why i was able to compile legion to WASM without the feature - it appears to be only used in serialization so there's no need for everyone to enable it unless they use serialization.