### PR TITLE
2 tiny docs improvements

### DIFF
--- a/src/internals/query/mod.rs
+++ b/src/internals/query/mod.rs
@@ -120,6 +120,8 @@ enum Cache {
 }
 
 /// Provides efficient means to iterate and filter entities in a world.
+///
+/// See the [module-level documentation](./index.html) for more details and examples.
 pub struct Query<V: IntoView, F: EntityFilter = <<V as IntoView>::View as DefaultFilter>::Filter> {
     _view: PhantomData<V>,
     filter: Mutex<F>,

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,5 @@
 //! Worlds store collections of entities. An entity is a collection of components, identified
-//! by a unique [Entity ID](struct.Entity.html).
+//! by a unique [Entity](struct.Entity.html) ID.
 //!
 //! # Creating a world
 //!


### PR DESCRIPTION
Some crates put examples on the struct, some on the module, I couldn't find the examples the first time i was looking for them because i am more used to docs on the struct so now i linked them explicitly. The standard library does it like this (e.g. [Rc](https://doc.rust-lang.org/std/rc/struct.Rc.html) struct links to rc module).

I would do the same for World vs world but it seems the links wouldn't sometimes work as reported in #195.

Also unified whether just "Entity" or "Entity ID" is part of the link.