### PR TITLE
Update repository link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,15 +3,12 @@ name = "legion"
 version = "0.3.0"
 description = "High performance entity component system (ECS) library"
 authors = ["Thomas Gillen <thomas.gillen@googlemail.com>"]
-repository = "https://github.com/TomGillen/legion"
+repository = "https://github.com/amethyst/legion"
 keywords = ["ecs", "game"]
 categories = ["game-engines", "data-structures"]
 readme = "readme.md"
 license = "MIT"
 edition = "2018"
-
-[badges]
-travis-ci = { repository = "TomGillen/legion", branch = "master" }
 
 [features]
 default = ["parallel", "serialize", "crossbeam-events", "codegen"]


### PR DESCRIPTION
Also remove the badges section since (a) legion now uses Github actions and (b) the badges section will actually be deprecated. See https://github.com/rust-lang/crates.io/issues/2436 for details.