### PR TITLE
Use a drop guard to prevent leaving a dangling reference in internals::serialize::id::run_as_context

### DIFF
--- a/src/internals/serialize/mod.rs
+++ b/src/internals/serialize/mod.rs
@@ -565,4 +565,19 @@ mod test {
 
         assert_eq!(8, world.len());
     }
+
+    #[test]
+    fn run_as_context_panic() {
+        std::panic::catch_unwind(|| {
+            let registry = Registry::<i32>::default();
+
+            super::WorldSerializer::with_entity_serializer(&registry, &mut |canon| {
+                super::id::run_as_context(canon, || panic!());
+            });
+        })
+        .unwrap_err();
+
+        // run the serialize_bincode test again
+        serialize_bincode();
+    }
 }


### PR DESCRIPTION
After reading about [the recent improvements to Miri](https://www.ralfj.de/blog/2020/09/28/miri.html), I tried using it to run Legion's tests. Most of them succeed, but `internals::serialize::test::serialize_bincode` and `internals::serialize::test::serialize_json` both panic for reasons I haven't looked into, and because they run in the same thread, the second one finds a dangling pointer and triggers an error in Miri.

This pull request fixes that problem, leaving both test results as panics rather than undefined behavior. The comment suggested using `catch_unwind` for this, but I used the more common and probably more efficient pattern of a guard struct with a `Drop` implementation that cleans up. I also added a small test to make sure Miri always has the opportunity to catch this bug, since it was essentially a coincidence that it was caught this time.