### PR TITLE
Use write_u64 to special-case hashing 64 bit values

### DIFF
--- a/src/internals/hash.rs
+++ b/src/internals/hash.rs
@@ -5,13 +5,21 @@ use std::hash::Hasher;
 pub struct ComponentTypeIdHasher(u64);
 
 impl Hasher for ComponentTypeIdHasher {
+    #[inline]
     fn finish(&self) -> u64 {
         self.0
     }
 
-    fn write(&mut self, bytes: &[u8]) {
-        use core::convert::TryInto;
-        self.0 = u64::from_ne_bytes(bytes.try_into().unwrap());
+    #[inline]
+    fn write_u64(&mut self, seed: u64) {
+        // This must only be used to hash one value.
+        debug_assert_eq!(self.0, 0);
+        self.0 = seed;
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        // This should not be called, only write_u64.
+        unimplemented!()
     }
 }
 
@@ -20,15 +28,23 @@ impl Hasher for ComponentTypeIdHasher {
 pub struct U64Hasher(u64);
 
 impl Hasher for U64Hasher {
+    #[inline]
     fn finish(&self) -> u64 {
         self.0
     }
 
-    fn write(&mut self, bytes: &[u8]) {
-        use core::convert::TryInto;
-        let seed = u64::from_ne_bytes(bytes.try_into().unwrap());
+    #[inline]
+    fn write_u64(&mut self, seed: u64) {
+        // This must only be used to hash one value.
+        debug_assert_eq!(self.0, 0);
+
         let max_prime = 11_400_714_819_323_198_549u64;
         self.0 = max_prime.wrapping_mul(seed);
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        // This should not be called, only write_u64.
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
This avoids the need for u64::from_ne_bytes.