### PR TITLE
Make CustomEntitySerializer public

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -36,7 +36,7 @@ pub use crate::internals::serialize::{
     de::WorldDeserializer,
     id::{Canon, EntityName, EntitySerializer},
     ser::{SerializableWorld, WorldSerializer},
-    AutoTypeKey, DeserializeIntoWorld, DeserializeNewWorld, Registry, TypeKey, UnknownType,
+    AutoTypeKey, CustomEntitySerializer, DeserializeIntoWorld, DeserializeNewWorld, Registry, TypeKey, UnknownType,
 };
 
 #[cfg(feature = "type-uuid")]


### PR DESCRIPTION
Could we make this trait public? It would be nice to implement it to control entity keys without worrying about the rest of serialization.