### PR TITLE
Re-export FetchMut from systems

### DIFF
--- a/src/systems.rs
+++ b/src/systems.rs
@@ -3,7 +3,8 @@
 pub use crate::internals::systems::{
     command::{CommandBuffer, WorldWritable},
     resources::{
-        Fetch, Resource, ResourceSet, ResourceTypeId, Resources, SyncResources, UnsafeResources,
+        Fetch, FetchMut, Resource, ResourceSet, ResourceTypeId, Resources, SyncResources,
+        UnsafeResources,
     },
     schedule::{Builder, Executor, ParallelRunnable, Runnable, Schedule, Step},
     system::{QuerySet, System, SystemAccess, SystemBuilder, SystemFn, SystemId},


### PR DESCRIPTION
Noticed this re-export was missing since the type didn't get linked properly on the return type in https://docs.rs/legion/0.3.1/legion/struct.Resources.html#method.get_mut.