### PR TITLE
SystemResources: port of specs' SystemData for resources

### DIFF
--- a/codegen/src/derive.rs
+++ b/codegen/src/derive.rs
@@ -1,0 +1,306 @@
+use syn::{
+    punctuated::Punctuated, token::Comma, Data, DataStruct, DeriveInput, Field, Fields,
+    FieldsNamed, FieldsUnnamed, GenericArgument, Ident, Lifetime, PathArguments, Type, TypePath,
+    WhereClause, WherePredicate,
+};
+
+/// Used to `#[derive]` the trait `IntoQuery`.
+///
+/// You need to have the following items included in the current scope:
+///
+/// * `IntoQuery`
+/// * `Query`
+
+pub fn impl_system_resources(ast: &DeriveInput) -> proc_macro2::TokenStream {
+    let name = &ast.ident;
+    let mut generics = ast.generics.clone();
+
+    let (_fetch_return, tys) = gen_from_body(&ast.data, name);
+    let tys = &tys;
+    // Assumes that the first lifetime is the fetch lt
+    let def_fetch_lt = ast
+        .generics
+        .lifetimes()
+        .next()
+        .expect("There has to be at least one lifetime");
+    let impl_fetch_lt = &def_fetch_lt.lifetime;
+
+    {
+        let where_clause = generics.make_where_clause();
+        constrain_system_data_types(where_clause, impl_fetch_lt, tys);
+    }
+    // Reads and writes are taken from the same types,
+    // but need to be cloned before.
+
+    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+
+    let system_resources_info = system_resources_info_from_ast(&ast.data);
+    let (write_resources, read_resources) =
+        partition_resources(&system_resources_info.resource_types);
+
+    let mut resource_types_iter = system_resources_info
+        .resource_types
+        .iter()
+        .cloned()
+        .rev()
+        .map(|resource_info| (resource_info.resource_type, resource_info.mutable));
+
+    let (mut cons_concat_arg_type, mut cons_concat_expr) = resource_types_iter.next().map_or(
+        (quote! { () }, quote! { () }),
+        |(resource_type, mutable)| {
+            if mutable {
+                (
+                    quote! { (Write< #resource_type >, ()) },
+                    quote! { (Write< #resource_type >::default(), ()) },
+                )
+            } else {
+                (
+                    quote! { (Read< #resource_type >, ()) },
+                    quote! { (Read::< #resource_type >::default(), ()) },
+                )
+            }
+        },
+    );
+
+    for (resource_type, mutable) in resource_types_iter {
+        cons_concat_arg_type = if mutable {
+            quote! { (Write< #resource_type >, #cons_concat_arg_type) }
+        } else {
+            quote! { (Read< #resource_type >, #cons_concat_arg_type) }
+        };
+
+        cons_concat_expr = if mutable {
+            quote! { (Write::< #resource_type >::default(), #cons_concat_expr) }
+        } else {
+            quote! { (Read::< #resource_type >::default(), #cons_concat_expr) }
+        };
+    }
+
+    let field_names = system_resources_info.field_names.clone();
+    let resource_fetches = system_resources_info
+        .resource_types
+        .iter()
+        .cloned()
+        .map(|resource_info| (resource_info.resource_type, resource_info.mutable))
+        .zip(field_names.iter())
+        .map(|((resource_type, mutable), field_name)| {
+            if mutable {
+                quote! {
+                    #field_name: {
+                        let type_id = &::legion::systems::ResourceTypeId::of::< #resource_type >();
+                        resources.get(&type_id).unwrap().get_mut::< #resource_type >().unwrap()
+                    },
+                }
+            } else {
+                quote! {
+                    #field_name: {
+                        let type_id = &::legion::systems::ResourceTypeId::of::< #resource_type >();
+                        resources.get(&type_id).unwrap().get::< #resource_type >().unwrap()
+                    },
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    quote! {
+        impl #ty_generics SystemResources<#impl_fetch_lt> for #name #ty_generics {
+            type ConsConcatArg = #cons_concat_arg_type;
+
+            fn resources() -> Self::ConsConcatArg {
+                #cons_concat_expr
+            }
+
+            fn read_resource_type_ids() -> Vec<::legion::systems::ResourceTypeId> {
+                let mut resource_type_ids = Vec::new();
+                #(
+                    resource_type_ids.push(::legion::systems::ResourceTypeId::of::< #read_resources >());
+                )*
+                resource_type_ids
+            }
+
+            fn write_resource_type_ids() -> Vec<::legion::systems::ResourceTypeId> {
+                let mut resource_type_ids = Vec::new();
+                #(
+                    resource_type_ids.push(::legion::systems::ResourceTypeId::of::< #write_resources >());
+                )*
+                resource_type_ids
+            }
+
+            unsafe fn fetch_unchecked(resources: & #impl_fetch_lt ::legion::systems::UnsafeResources) -> Self {
+                // TODO: support tuple structs
+                Self { #(
+                    #resource_fetches
+                )* }
+            }
+        }
+    }
+}
+
+fn collect_field_types(fields: &Punctuated<Field, Comma>) -> Vec<Type> {
+    fields.iter().map(|x| x.ty.clone()).collect()
+}
+
+fn gen_identifiers(fields: &Punctuated<Field, Comma>) -> Vec<Ident> {
+    fields.iter().map(|x| x.ident.clone().unwrap()).collect()
+}
+
+/// Adds a `IntoQuery<'lt>` bound on each of the system data types.
+fn constrain_system_data_types(clause: &mut WhereClause, fetch_lt: &Lifetime, tys: &[Type]) {
+    for ty in tys.iter() {
+        let where_predicate: WherePredicate = parse_quote!(#ty : IntoQuery< #fetch_lt >);
+        clause.predicates.push(where_predicate);
+    }
+}
+
+#[derive(Clone)]
+enum DataType {
+    Struct,
+    Tuple,
+}
+
+#[derive(Clone)]
+struct ResourceInfo {
+    mutable: bool,
+    resource_type: Type,
+}
+
+#[derive(Clone)]
+struct SystemResourcesInfo {
+    data_type: DataType,
+    field_names: Vec<Ident>,
+    struct_types: Vec<Type>,
+    // Component names (stripped out references from struct_fields).
+    resource_types: Vec<ResourceInfo>,
+}
+
+fn partition_resources(resource_types: &[ResourceInfo]) -> (Vec<Type>, Vec<Type>) {
+    let (write_resources, read_resources) = resource_types
+        .iter()
+        .cloned()
+        .partition::<Vec<_>, _>(|resource_type| resource_type.mutable);
+
+    fn map_type(resource_info: ResourceInfo) -> Type {
+        resource_info.resource_type
+    }
+
+    let write_resources = write_resources.into_iter().map(map_type).collect();
+    let read_resources = read_resources.into_iter().map(map_type).collect();
+
+    (write_resources, read_resources)
+}
+
+fn system_resources_info_from_ast(ast: &Data) -> SystemResourcesInfo {
+    let (data_type, fields) = match *ast {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(FieldsNamed { named: ref x, .. }),
+            ..
+        }) => (DataType::Struct, x),
+        Data::Struct(DataStruct {
+            fields: Fields::Unnamed(FieldsUnnamed { unnamed: ref x, .. }),
+            ..
+        }) => (DataType::Tuple, x),
+        _ => panic!("Enums are not supported"),
+    };
+
+    let field_names = if let DataType::Struct = data_type {
+        fields
+            .iter()
+            .map(|field| {
+                field
+                    .ident
+                    .clone()
+                    .expect("Expected a name for a named struct field")
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let mut struct_types = Vec::with_capacity(fields.len());
+    let mut resource_types = Vec::with_capacity(fields.len());
+
+    for field in fields {
+        match &field.ty {
+            Type::Reference(_) => {
+                panic!("Only Fetch or FetchMut are supported");
+            }
+            Type::Path(type_path) => {
+                let resources_type = try_fetch_type(type_path.clone());
+                struct_types.push(Type::Path(type_path.clone()));
+                resource_types.push(resources_type);
+            }
+            _ => panic!("Only reference or Option types are supported"),
+        }
+    }
+
+    SystemResourcesInfo {
+        data_type,
+        field_names,
+        struct_types,
+        resource_types,
+    }
+}
+
+fn try_fetch_type(type_path: TypePath) -> ResourceInfo {
+    let last_path_segment = type_path.path.segments.last().unwrap();
+    // TODO: support for custom paths, if it's possible to pass with macro attributes
+    let mutable = match last_path_segment.ident.to_string().as_ref() {
+        "Fetch" => false,
+        "FetchMut" => true,
+        _ => panic!("meh"),
+    };
+
+    let resource_type =
+        if let PathArguments::AngleBracketed(generic_arguments) = &last_path_segment.arguments {
+            if let GenericArgument::Type(type_arg) = generic_arguments.args.last().unwrap() {
+                type_arg.clone()
+            } else {
+                panic!("Expected a type as the last generic argument for Fetch or FetchMut");
+            }
+        } else {
+            panic!("Expected generic arguments for Fetch or FetchMut");
+        };
+
+    ResourceInfo {
+        mutable,
+        resource_type,
+    }
+}
+
+fn gen_from_body(ast: &Data, name: &Ident) -> (proc_macro2::TokenStream, Vec<Type>) {
+    let (body, fields) = match *ast {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(FieldsNamed { named: ref x, .. }),
+            ..
+        }) => (DataType::Struct, x),
+        Data::Struct(DataStruct {
+            fields: Fields::Unnamed(FieldsUnnamed { unnamed: ref x, .. }),
+            ..
+        }) => (DataType::Tuple, x),
+        _ => panic!("Enums are not supported"),
+    };
+
+    let tys = collect_field_types(fields);
+
+    let fetch_return = match body {
+        DataType::Struct => {
+            let identifiers = gen_identifiers(fields);
+
+            quote! {
+                #name {
+                    #( #identifiers: IntoQuery::fetch(world) ),*
+                }
+            }
+        }
+        DataType::Tuple => {
+            let count = tys.len();
+            let fetch = vec![quote! { IntoQuery::fetch(world) }; count];
+
+            quote! {
+                #name ( #( #fetch ),* )
+            }
+        }
+    };
+
+    (fetch_return, tys)
+}

--- a/codegen/src/derive.rs
+++ b/codegen/src/derive.rs
@@ -1,22 +1,12 @@
+use quote::quote;
 use syn::{
-    punctuated::Punctuated, token::Comma, Data, DataStruct, DeriveInput, Field, Fields,
-    FieldsNamed, FieldsUnnamed, GenericArgument, Ident, Lifetime, PathArguments, Type, TypePath,
-    WhereClause, WherePredicate,
+    Data, DataStruct, DeriveInput, Fields, FieldsNamed, FieldsUnnamed, GenericArgument, Ident,
+    PathArguments, Type, TypePath,
 };
-
-/// Used to `#[derive]` the trait `IntoQuery`.
-///
-/// You need to have the following items included in the current scope:
-///
-/// * `IntoQuery`
-/// * `Query`
 
 pub fn impl_system_resources(ast: &DeriveInput) -> proc_macro2::TokenStream {
     let name = &ast.ident;
-    let mut generics = ast.generics.clone();
 
-    let (_fetch_return, tys) = gen_from_body(&ast.data, name);
-    let tys = &tys;
     // Assumes that the first lifetime is the fetch lt
     let def_fetch_lt = ast
         .generics
@@ -25,89 +15,97 @@ pub fn impl_system_resources(ast: &DeriveInput) -> proc_macro2::TokenStream {
         .expect("There has to be at least one lifetime");
     let impl_fetch_lt = &def_fetch_lt.lifetime;
 
-    {
-        let where_clause = generics.make_where_clause();
-        constrain_system_data_types(where_clause, impl_fetch_lt, tys);
-    }
-    // Reads and writes are taken from the same types,
-    // but need to be cloned before.
-
-    let (_impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
     let system_resources_info = system_resources_info_from_ast(&ast.data);
     let (write_resources, read_resources) =
         partition_resources(&system_resources_info.resource_types);
 
-    let mut resource_types_iter = system_resources_info
+    let (cons_append_arg_type, cons_append_expr) = system_resources_info
         .resource_types
         .iter()
         .cloned()
         .rev()
-        .map(|resource_info| (resource_info.resource_type, resource_info.mutable));
+        .map(|resource_info| (resource_info.resource_type, resource_info.mutable))
+        .fold(
+            (quote! { () }, quote! { () }),
+            |(mut cons_append_arg_type, mut cons_append_expr), (resource_type, mutable)| {
+                cons_append_arg_type = if mutable {
+                    quote! { (Write< #resource_type >, #cons_append_arg_type) }
+                } else {
+                    quote! { (Read< #resource_type >, #cons_append_arg_type) }
+                };
 
-    let (mut cons_concat_arg_type, mut cons_concat_expr) = resource_types_iter.next().map_or(
-        (quote! { () }, quote! { () }),
-        |(resource_type, mutable)| {
-            if mutable {
-                (
-                    quote! { (Write< #resource_type >, ()) },
-                    quote! { (Write< #resource_type >::default(), ()) },
-                )
-            } else {
-                (
-                    quote! { (Read< #resource_type >, ()) },
-                    quote! { (Read::< #resource_type >::default(), ()) },
-                )
-            }
-        },
-    );
+                cons_append_expr = if mutable {
+                    quote! { (Write::< #resource_type >::default(), #cons_append_expr) }
+                } else {
+                    quote! { (Read::< #resource_type >::default(), #cons_append_expr) }
+                };
 
-    for (resource_type, mutable) in resource_types_iter {
-        cons_concat_arg_type = if mutable {
-            quote! { (Write< #resource_type >, #cons_concat_arg_type) }
-        } else {
-            quote! { (Read< #resource_type >, #cons_concat_arg_type) }
-        };
-
-        cons_concat_expr = if mutable {
-            quote! { (Write::< #resource_type >::default(), #cons_concat_expr) }
-        } else {
-            quote! { (Read::< #resource_type >::default(), #cons_concat_expr) }
-        };
-    }
+                (cons_append_arg_type, cons_append_expr)
+            },
+        );
 
     let field_names = system_resources_info.field_names.clone();
+
     let resource_fetches = system_resources_info
         .resource_types
         .iter()
         .cloned()
         .map(|resource_info| (resource_info.resource_type, resource_info.mutable))
-        .zip(field_names.iter())
-        .map(|((resource_type, mutable), field_name)| {
+        .map(|(resource_type, mutable)| {
             if mutable {
                 quote! {
-                    #field_name: {
+                    {
                         let type_id = &::legion::systems::ResourceTypeId::of::< #resource_type >();
                         resources.get(&type_id).unwrap().get_mut::< #resource_type >().unwrap()
-                    },
+                    }
                 }
             } else {
                 quote! {
-                    #field_name: {
+                    {
                         let type_id = &::legion::systems::ResourceTypeId::of::< #resource_type >();
                         resources.get(&type_id).unwrap().get::< #resource_type >().unwrap()
-                    },
+                    }
                 }
             }
         })
         .collect::<Vec<_>>();
 
+    let return_statement = match system_resources_info.data_type {
+        DataType::Struct => {
+            let named_args = resource_fetches
+                .iter()
+                .zip(field_names.iter())
+                .map(|(resource_fetch, field_name)| {
+                    quote! { #field_name: #resource_fetch }
+                })
+                .collect::<Vec<_>>();
+            quote! {
+                Self {
+                    #(
+                        #named_args,
+                    )*
+                }
+            }
+        }
+        DataType::Tuple => {
+            quote! {
+                Self(
+                    #(
+                        #resource_fetches,
+                    )*
+                )
+            }
+        }
+    };
+
     quote! {
-        impl #ty_generics SystemResources<#impl_fetch_lt> for #name #ty_generics {
-            type ConsConcatArg = #cons_concat_arg_type;
+        impl #impl_generics SystemResources<#impl_fetch_lt> for #name #ty_generics #where_clause {
+            type ConsConcatArg = #cons_append_arg_type;
 
             fn resources() -> Self::ConsConcatArg {
-                #cons_concat_expr
+                #cons_append_expr
             }
 
             fn read_resource_type_ids() -> Vec<::legion::systems::ResourceTypeId> {
@@ -127,28 +125,9 @@ pub fn impl_system_resources(ast: &DeriveInput) -> proc_macro2::TokenStream {
             }
 
             unsafe fn fetch_unchecked(resources: & #impl_fetch_lt ::legion::systems::UnsafeResources) -> Self {
-                // TODO: support tuple structs
-                Self { #(
-                    #resource_fetches
-                )* }
+                #return_statement
             }
         }
-    }
-}
-
-fn collect_field_types(fields: &Punctuated<Field, Comma>) -> Vec<Type> {
-    fields.iter().map(|x| x.ty.clone()).collect()
-}
-
-fn gen_identifiers(fields: &Punctuated<Field, Comma>) -> Vec<Ident> {
-    fields.iter().map(|x| x.ident.clone().unwrap()).collect()
-}
-
-/// Adds a `IntoQuery<'lt>` bound on each of the system data types.
-fn constrain_system_data_types(clause: &mut WhereClause, fetch_lt: &Lifetime, tys: &[Type]) {
-    for ty in tys.iter() {
-        let where_predicate: WherePredicate = parse_quote!(#ty : IntoQuery< #fetch_lt >);
-        clause.predicates.push(where_predicate);
     }
 }
 
@@ -221,15 +200,12 @@ fn system_resources_info_from_ast(ast: &Data) -> SystemResourcesInfo {
 
     for field in fields {
         match &field.ty {
-            Type::Reference(_) => {
-                panic!("Only Fetch or FetchMut are supported");
-            }
             Type::Path(type_path) => {
                 let resources_type = try_fetch_type(type_path.clone());
                 struct_types.push(Type::Path(type_path.clone()));
                 resource_types.push(resources_type);
             }
-            _ => panic!("Only reference or Option types are supported"),
+            _ => panic!("Only Fetch or FetchMut are supported"),
         }
     }
 
@@ -243,11 +219,11 @@ fn system_resources_info_from_ast(ast: &Data) -> SystemResourcesInfo {
 
 fn try_fetch_type(type_path: TypePath) -> ResourceInfo {
     let last_path_segment = type_path.path.segments.last().unwrap();
-    // TODO: support for custom paths, if it's possible to pass with macro attributes
+    // TODO: support for custom paths if it's possible to pass them with macro attributes.
     let mutable = match last_path_segment.ident.to_string().as_ref() {
         "Fetch" => false,
         "FetchMut" => true,
-        _ => panic!("meh"),
+        _ => panic!("Only Fetch or FetchMut are supported"),
     };
 
     let resource_type =
@@ -265,42 +241,4 @@ fn try_fetch_type(type_path: TypePath) -> ResourceInfo {
         mutable,
         resource_type,
     }
-}
-
-fn gen_from_body(ast: &Data, name: &Ident) -> (proc_macro2::TokenStream, Vec<Type>) {
-    let (body, fields) = match *ast {
-        Data::Struct(DataStruct {
-            fields: Fields::Named(FieldsNamed { named: ref x, .. }),
-            ..
-        }) => (DataType::Struct, x),
-        Data::Struct(DataStruct {
-            fields: Fields::Unnamed(FieldsUnnamed { unnamed: ref x, .. }),
-            ..
-        }) => (DataType::Tuple, x),
-        _ => panic!("Enums are not supported"),
-    };
-
-    let tys = collect_field_types(fields);
-
-    let fetch_return = match body {
-        DataType::Struct => {
-            let identifiers = gen_identifiers(fields);
-
-            quote! {
-                #name {
-                    #( #identifiers: IntoQuery::fetch(world) ),*
-                }
-            }
-        }
-        DataType::Tuple => {
-            let count = tys.len();
-            let fetch = vec![quote! { IntoQuery::fetch(world) }; count];
-
-            quote! {
-                #name ( #( #fetch ),* )
-            }
-        }
-    };
-
-    (fetch_return, tys)
 }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,12 +1,5 @@
 #![recursion_limit = "256"]
 
-extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
-
 mod derive;
 
 use proc_macro::TokenStream;
@@ -16,8 +9,6 @@ use syn::{
     parse_macro_input, parse_quote, Attribute, Expr, GenericArgument, Generics, Ident, Index,
     ItemFn, Lit, Meta, PathArguments, Signature, Type, Visibility,
 };
-
-// pub mod derive;
 
 /// Wraps a function in a system, and generates a new function which constructs that system.
 ///
@@ -182,7 +173,6 @@ pub fn system(attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_derive(SystemResources)]
-// TODO: accept legion crate name parameter
 pub fn system_resources(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,4 +1,14 @@
+#![recursion_limit = "256"]
+
 extern crate proc_macro;
+extern crate proc_macro2;
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+
+mod derive;
+
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote, quote_spanned};
@@ -6,6 +16,8 @@ use syn::{
     parse_macro_input, parse_quote, Attribute, Expr, GenericArgument, Generics, Ident, Index,
     ItemFn, Lit, Meta, PathArguments, Signature, Type, Visibility,
 };
+
+// pub mod derive;
 
 /// Wraps a function in a system, and generates a new function which constructs that system.
 ///
@@ -167,6 +179,16 @@ pub fn system(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     TokenStream::from(output)
+}
+
+#[proc_macro_derive(SystemResources)]
+// TODO: accept legion crate name parameter
+pub fn system_resources(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+
+    let gen = derive::impl_system_resources(&ast);
+
+    gen.into()
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/src/internals/cons.rs
+++ b/src/internals/cons.rs
@@ -71,6 +71,29 @@ impl<T, A, B: ConsAppend<T>> ConsAppend<T> for (A, B) {
     }
 }
 
+/// Concat a cons list with another one.
+pub trait ConsConcat<T> {
+    /// Result of concat
+    type Output;
+    /// Concat to runtime cons value
+    fn concat(self, t: T) -> Self::Output;
+}
+
+impl<T> ConsConcat<T> for () {
+    type Output = T;
+    fn concat(self, t: T) -> Self::Output {
+        t
+    }
+}
+
+impl<T, A, B: ConsConcat<T>> ConsConcat<T> for (A, B) {
+    type Output = (A, <B as ConsConcat<T>>::Output);
+    fn concat(self, t: T) -> Self::Output {
+        let (a, b) = self;
+        (a, b.concat(t))
+    }
+}
+
 /// transform cons list into a flat tuple
 pub trait ConsFlatten {
     /// Flattened tuple

--- a/src/internals/query/view/mod.rs
+++ b/src/internals/query/view/mod.rs
@@ -22,6 +22,7 @@ use std::marker::PhantomData;
 
 pub mod entity;
 pub mod read;
+pub mod system_resources_view;
 pub mod try_read;
 pub mod try_write;
 pub mod write;

--- a/src/internals/query/view/system_resources_view.rs
+++ b/src/internals/query/view/system_resources_view.rs
@@ -1,0 +1,15 @@
+#![doc(hidden)]
+
+use super::ReadOnly;
+
+use derivative::Derivative;
+use std::marker::PhantomData;
+
+/// TODO: better name?
+#[derive(Derivative, Debug, Copy, Clone)]
+#[derivative(Default(bound = ""))]
+pub struct SystemResourcesView<T>(PhantomData<*const T>);
+
+unsafe impl<T> Send for SystemResourcesView<T> {}
+unsafe impl<T: Sync> Sync for SystemResourcesView<T> {}
+unsafe impl<T> ReadOnly for SystemResourcesView<T> {}

--- a/src/internals/systems/resources.rs
+++ b/src/internals/systems/resources.rs
@@ -18,6 +18,8 @@ use std::{
     ops::{Deref, DerefMut},
     sync::atomic::AtomicIsize,
 };
+use crate::internals::query::view::system_resources_view::SystemResourcesView;
+use crate::system_data::SystemResources;
 
 /// Unique ID for a resource.
 #[derive(Copy, Clone, Debug, Eq, PartialOrd, Ord)]
@@ -140,6 +142,14 @@ impl<'a, T: Resource> ResourceSet<'a> for Write<T> {
     unsafe fn fetch_unchecked(resources: &'a UnsafeResources) -> Self::Result {
         let type_id = &ResourceTypeId::of::<T>();
         resources.get(&type_id).unwrap().get_mut::<T>().unwrap()
+    }
+}
+
+impl<'a, S: 'a + SystemResources<'a>> ResourceSet<'a> for SystemResourcesView<S> {
+    type Result = S;
+
+    unsafe fn fetch_unchecked(resources: &'a UnsafeResources) -> Self::Result {
+        S::fetch_unchecked(resources)
     }
 }
 
@@ -358,7 +368,8 @@ impl UnsafeResources {
         self.map.remove(type_id).map(|cell| cell.into_inner())
     }
 
-    fn get(&self, type_id: &ResourceTypeId) -> Option<&ResourceCell> {
+    /// TODO
+    pub fn get(&self, type_id: &ResourceTypeId) -> Option<&ResourceCell> {
         self.map.get(type_id)
     }
 

--- a/src/internals/systems/resources.rs
+++ b/src/internals/systems/resources.rs
@@ -3,10 +3,12 @@
 //! Use resources to share persistent data between systems or to provide a system with state
 //! external to entities.
 
+use crate::internals::query::view::system_resources_view::SystemResourcesView;
 use crate::internals::{
     hash::ComponentTypeIdHasher,
     query::view::{read::Read, write::Write, ReadOnly},
 };
+use crate::system_data::SystemResources;
 use downcast_rs::{impl_downcast, Downcast};
 use std::{
     any::TypeId,
@@ -18,8 +20,6 @@ use std::{
     ops::{Deref, DerefMut},
     sync::atomic::AtomicIsize,
 };
-use crate::internals::query::view::system_resources_view::SystemResourcesView;
-use crate::system_data::SystemResources;
 
 /// Unique ID for a resource.
 #[derive(Copy, Clone, Debug, Eq, PartialOrd, Ord)]

--- a/src/internals/systems/system.rs
+++ b/src/internals/systems/system.rs
@@ -6,13 +6,14 @@ use super::{
     schedule::Runnable,
 };
 
-
 use crate::internals::{
     cons::{ConsAppend, ConsFlatten},
     permissions::Permissions,
     query::{
         filter::EntityFilter,
-        view::{read::Read, write::Write, IntoView, View},
+        view::{
+            read::Read, system_resources_view::SystemResourcesView, write::Write, IntoView, View,
+        },
         Query,
     },
     storage::{
@@ -22,10 +23,9 @@ use crate::internals::{
     subworld::{ArchetypeAccess, ComponentAccess, SubWorld},
     world::{World, WorldId},
 };
-use crate::system_data::{SystemResources};
+use crate::system_data::SystemResources;
 use bit_set::BitSet;
 use std::{any::TypeId, borrow::Cow, collections::HashMap, marker::PhantomData};
-use crate::internals::query::view::system_resources_view::SystemResourcesView;
 
 /// Provides an abstraction across tuples of queries for system closures.
 pub trait QuerySet: Send + Sync {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,9 +190,16 @@ pub mod query;
 pub mod storage;
 pub mod systems;
 pub mod world;
+pub mod system_data;
 
 #[cfg(feature = "serialize")]
 pub mod serialize;
+
+// useful for users who want to construct their wrappers around SystemBuilder
+/// TODO: this is probably a bit weird way to re-export these
+pub mod cons {
+    pub use super::internals::cons::{ConsFlatten, ConsAppend, ConsPrepend};
+}
 
 // re-export most common types into the root
 pub use crate::{
@@ -206,7 +213,7 @@ pub use crate::{
 };
 
 #[cfg(feature = "codegen")]
-pub use legion_codegen::system;
+pub use legion_codegen::{system, SystemResources};
 
 #[cfg(feature = "serialize")]
 pub use crate::serialize::Registry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,9 +188,9 @@ mod internals;
 // public API organized into logical modules
 pub mod query;
 pub mod storage;
+pub mod system_data;
 pub mod systems;
 pub mod world;
-pub mod system_data;
 
 #[cfg(feature = "serialize")]
 pub mod serialize;
@@ -198,7 +198,7 @@ pub mod serialize;
 // useful for users who want to construct their wrappers around SystemBuilder
 /// TODO: this is probably a bit weird way to re-export these
 pub mod cons {
-    pub use super::internals::cons::{ConsFlatten, ConsAppend, ConsPrepend};
+    pub use super::internals::cons::{ConsAppend, ConsFlatten, ConsPrepend};
 }
 
 // re-export most common types into the root

--- a/src/system_data.rs
+++ b/src/system_data.rs
@@ -1,0 +1,35 @@
+//! TODO
+
+
+use crate::internals::systems::resources::{ResourceTypeId, UnsafeResources};
+
+
+
+/// TODO
+pub trait SystemResources<'a> {
+    /// TODO
+    type ConsConcatArg;
+
+    /// TODO
+    fn resources() -> Self::ConsConcatArg;
+
+    /// TODO
+    unsafe fn fetch_unchecked(resources: &'a UnsafeResources) -> Self;
+
+    /// TODO
+    fn read_resource_type_ids() -> Vec<ResourceTypeId>;
+
+    /// TODO
+    fn write_resource_type_ids() -> Vec<ResourceTypeId>;
+}
+
+
+
+/// TODO
+pub trait SystemView {
+    // /// TODO
+    // fn register<Q, R>(system_builder: SystemBuilder<Q, R>) -> SystemBuilder<Q, R>
+    // where
+    //     Q: 'static + Send + ConsFlatten,
+    //     R: 'static + ConsFlatten;
+}

--- a/src/system_data.rs
+++ b/src/system_data.rs
@@ -19,12 +19,3 @@ pub trait SystemResources<'a> {
     /// TODO
     fn write_resource_type_ids() -> Vec<ResourceTypeId>;
 }
-
-/// TODO
-pub trait SystemView {
-    // /// TODO
-    // fn register<Q, R>(system_builder: SystemBuilder<Q, R>) -> SystemBuilder<Q, R>
-    // where
-    //     Q: 'static + Send + ConsFlatten,
-    //     R: 'static + ConsFlatten;
-}

--- a/src/system_data.rs
+++ b/src/system_data.rs
@@ -1,9 +1,6 @@
 //! TODO
 
-
 use crate::internals::systems::resources::{ResourceTypeId, UnsafeResources};
-
-
 
 /// TODO
 pub trait SystemResources<'a> {
@@ -22,8 +19,6 @@ pub trait SystemResources<'a> {
     /// TODO
     fn write_resource_type_ids() -> Vec<ResourceTypeId>;
 }
-
-
 
 /// TODO
 pub trait SystemView {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -3,7 +3,8 @@
 pub use crate::internals::systems::{
     command::{CommandBuffer, WorldWritable},
     resources::{
-        Fetch, Resource, ResourceSet, ResourceTypeId, Resources, SyncResources, UnsafeResources,
+        Fetch, FetchMut, Resource, ResourceSet, ResourceTypeId, Resources, SyncResources,
+        UnsafeResources,
     },
     schedule::{Builder, Executor, ParallelRunnable, Runnable, Schedule, Step},
     system::{QuerySet, System, SystemAccess, SystemBuilder, SystemFn, SystemId},

--- a/tests/failures/value_argument.stderr
+++ b/tests/failures/value_argument.stderr
@@ -1,4 +1,4 @@
-error: system function parameters must be `CommandBuffer` or `SubWorld` references, [optioned] component references, state references, or resource references
+error: system function parameters must be `CommandBuffer` or `SubWorld` references, [optioned] component references, state references, resource references, or references to structs deriving SystemResources
  --> $DIR/value_argument.rs:4:23
   |
 4 | fn value_arguement(_: usize) {}

--- a/tests/system_resources.rs
+++ b/tests/system_resources.rs
@@ -1,0 +1,32 @@
+use crate::system_data::SystemResources;
+use legion::systems::Fetch;
+use legion::*;
+
+#[test]
+#[cfg(feature = "codegen")]
+fn basic_system() {
+    pub struct TestA(usize);
+    pub struct TestB(usize);
+
+    #[derive(SystemResources)]
+    pub struct TestSystemResources<'a> {
+        test_a: Fetch<'a, TestA>,
+        test_b: Fetch<'a, TestB>,
+    }
+
+    let test = SystemBuilder::new("test")
+        .register_system_resources::<TestSystemResources<'static>>()
+        .build(|_, _, test_resources, _| {
+            assert_eq!(test_resources.test_a.0, 1);
+            assert_eq!(test_resources.test_b.0, 2);
+        });
+
+    let mut resources = Resources::default();
+    resources.insert(TestA(1));
+    resources.insert(TestB(2));
+
+    let mut world = World::default();
+    let mut schedule = Schedule::builder().add_system(test).build();
+
+    schedule.execute(&mut world, &mut resources);
+}

--- a/tests/system_resources.rs
+++ b/tests/system_resources.rs
@@ -1,32 +1,135 @@
-use crate::system_data::SystemResources;
-use legion::systems::Fetch;
-use legion::*;
-
-#[test]
 #[cfg(feature = "codegen")]
-fn basic_system() {
+mod tests {
+    use legion::system_data::SystemResources;
+    use legion::systems::{Fetch, FetchMut};
+    use legion::*;
+
     pub struct TestA(usize);
     pub struct TestB(usize);
 
-    #[derive(SystemResources)]
-    pub struct TestSystemResources<'a> {
-        test_a: Fetch<'a, TestA>,
-        test_b: Fetch<'a, TestB>,
+    #[test]
+    fn basic() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a> {
+            test_a: Fetch<'a, TestA>,
+            test_b: Fetch<'a, TestB>,
+        }
+
+        let test = SystemBuilder::new("test")
+            .register_system_resources::<TestSystemResources<'static>>()
+            .build(|_, _, test_resources, _| {
+                let test_resources: &TestSystemResources = test_resources;
+                assert_eq!(test_resources.test_a.0, 1);
+                assert_eq!(test_resources.test_b.0, 2);
+            });
+
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
+
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(test).build();
+
+        schedule.execute(&mut world, &mut resources);
     }
 
-    let test = SystemBuilder::new("test")
-        .register_system_resources::<TestSystemResources<'static>>()
-        .build(|_, _, test_resources, _| {
+    #[test]
+    fn with_immutable() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a> {
+            test_a: Fetch<'a, TestA>,
+            test_b: Fetch<'a, TestB>,
+        }
+
+        #[system]
+        fn basic(#[system_resources] test_resources: &TestSystemResources<'static>) {
             assert_eq!(test_resources.test_a.0, 1);
             assert_eq!(test_resources.test_b.0, 2);
-        });
+        }
 
-    let mut resources = Resources::default();
-    resources.insert(TestA(1));
-    resources.insert(TestB(2));
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
 
-    let mut world = World::default();
-    let mut schedule = Schedule::builder().add_system(test).build();
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(basic_system()).build();
 
-    schedule.execute(&mut world, &mut resources);
+        schedule.execute(&mut world, &mut resources);
+    }
+
+    #[test]
+    fn with_mutable() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a> {
+            test_a: FetchMut<'a, TestA>,
+            test_b: Fetch<'a, TestB>,
+        }
+
+        #[system]
+        fn basic(#[system_resources] test_resources: &mut TestSystemResources<'static>) {
+            test_resources.test_a.0 = test_resources.test_b.0;
+        }
+
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
+
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(basic_system()).build();
+
+        schedule.execute(&mut world, &mut resources);
+
+        assert_eq!(resources.get::<TestA>().unwrap().0, 2);
+    }
+
+    #[test]
+    fn with_other_resources() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a> {
+            test_b: Fetch<'a, TestB>,
+        }
+
+        #[system]
+        fn basic(
+            #[system_resources] test_resources: &TestSystemResources<'static>,
+            #[resource] test_a: &mut TestA,
+        ) {
+            test_a.0 = test_resources.test_b.0;
+        }
+
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
+
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(basic_system()).build();
+
+        schedule.execute(&mut world, &mut resources);
+
+        assert_eq!(resources.get::<TestA>().unwrap().0, 2);
+    }
+
+    #[test]
+    fn with_for_each() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a> {
+            test_a: Fetch<'a, TestA>,
+            test_b: Fetch<'a, TestB>,
+        }
+
+        #[system(for_each)]
+        fn basic(_: &Entity, #[system_resources] test_resources: &TestSystemResources<'static>) {
+            assert_eq!(test_resources.test_a.0, 1);
+            assert_eq!(test_resources.test_b.0, 2);
+        }
+
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
+
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(basic_system()).build();
+
+        schedule.execute(&mut world, &mut resources);
+    }
 }

--- a/tests/system_resources.rs
+++ b/tests/system_resources.rs
@@ -67,7 +67,7 @@ mod tests {
 
         #[system]
         fn basic(#[system_resources] test_resources: &mut TestSystemResources<'static>) {
-            test_resources.test_a.0 = test_resources.test_b.0;
+            test_resources.test_a.0 += test_resources.test_b.0 * 2;
         }
 
         let mut resources = Resources::default();
@@ -79,7 +79,84 @@ mod tests {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(resources.get::<TestA>().unwrap().0, 2);
+        assert_eq!(resources.get::<TestA>().unwrap().0, 5);
+    }
+
+    #[test]
+    fn with_tuple_struct() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a>(FetchMut<'a, TestA>, Fetch<'a, TestB>);
+
+        #[system]
+        fn basic(#[system_resources] test_resources: &mut TestSystemResources<'static>) {
+            (test_resources.0).0 += (test_resources.1).0 * 2;
+        }
+
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
+
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(basic_system()).build();
+
+        schedule.execute(&mut world, &mut resources);
+
+        assert_eq!(resources.get::<TestA>().unwrap().0, 5);
+    }
+
+    #[test]
+    fn with_generics() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a, R1, R2: 'static>
+        where
+            R1: 'static,
+        {
+            test_a: FetchMut<'a, R1>,
+            test_b: Fetch<'a, R2>,
+        }
+
+        #[system]
+        fn basic(
+            #[system_resources] test_resources: &mut TestSystemResources<'static, TestA, TestB>,
+        ) {
+            test_resources.test_a.0 += test_resources.test_b.0 * 2;
+        }
+
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
+
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(basic_system()).build();
+
+        schedule.execute(&mut world, &mut resources);
+
+        assert_eq!(resources.get::<TestA>().unwrap().0, 5);
+    }
+
+    #[test]
+    fn with_several_system_resources() {
+        #[derive(SystemResources)]
+        pub struct TestSystemResources<'a, R: 'static>(FetchMut<'a, R>);
+
+        #[system]
+        fn basic(
+            #[system_resources] test_resources_a: &mut TestSystemResources<'static, TestA>,
+            #[system_resources] test_resources_b: &mut TestSystemResources<'static, TestB>,
+        ) {
+            (test_resources_a.0).0 += (test_resources_b.0).0 * 2;
+        }
+
+        let mut resources = Resources::default();
+        resources.insert(TestA(1));
+        resources.insert(TestB(2));
+
+        let mut world = World::default();
+        let mut schedule = Schedule::builder().add_system(basic_system()).build();
+
+        schedule.execute(&mut world, &mut resources);
+
+        assert_eq!(resources.get::<TestA>().unwrap().0, 5);
     }
 
     #[test]
@@ -94,7 +171,7 @@ mod tests {
             #[system_resources] test_resources: &TestSystemResources<'static>,
             #[resource] test_a: &mut TestA,
         ) {
-            test_a.0 = test_resources.test_b.0;
+            test_a.0 += test_resources.test_b.0 * 2;
         }
 
         let mut resources = Resources::default();
@@ -106,7 +183,7 @@ mod tests {
 
         schedule.execute(&mut world, &mut resources);
 
-        assert_eq!(resources.get::<TestA>().unwrap().0, 2);
+        assert_eq!(resources.get::<TestA>().unwrap().0, 5);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

This PR introduces a new derive macro inspired by specs' `#[derive(SystemData)]`, that can be used as follows:

```
pub struct TestA(usize);
pub struct TestB(usize);

#[derive(SystemResources)]
pub struct TestSystemResources<'a> {
    test_a: FetchMut<'a, TestA>,
    test_b: Fetch<'a, TestB>,
}

#[system]
fn basic(#[system_resources] test_resources: &mut TestSystemResources<'static>) {
    test_resources.test_a.0 += test_resources.test_b.0 * 2;
}
````

I see this feature useful in the following scenarious:
1. Working around [`ResourceSet`](https://docs.rs/legion/0.3.1/legion/resource/trait.ResourceSet.html) and [`ConsAppend`](https://docs.rs/legion/0.3.1/legion/storage/trait.ConsFlatten.html) limits of generic arguments number.
2. Attaching an implementation to a set of resources. Some functionality may have sense only when there are several resources present at once. Here's an example of how I use this pattern in Grumpy Visitors to combine the functionality of Amethyst's `Time` and my custom `GameTime` resources: https://github.com/amethyst/grumpy_visitors/blob/f12b85d0dac07c101b43e83711b89777dc69dd58/libs/core/src/ecs/system_data/time.rs.
3. Avoiding boilerplate, when there are a lot of common resources shared between other systems.

## Notable changes
Apart from implementing the feature itself, I had to do some other changes to the codebase.

1. Getting rid of `for<'a>` lifetime bounds for `ResourceSet` in favour of just `'static` lifetime.
```
-        <R as ConsFlatten>::Output: for<'a> ResourceSet<'a>,
+        <R as ConsFlatten>::Output: ResourceSet<'static>,
```

"Any" lifetime doesn't work well with the fact that `SystemResources` has its own lifetime. I didn't figure out the way to implement `ResourceSet` for `SystemResources`, so it supports the HRTB magic. Without this change I was getting the following error:
```
error: implementation of `ResourceSet` is not general enough
   --> tests\system_resources.rs:23:10
    |
23  |           .build(|_, _, (test_resources), _| {
    |            ^^^^^ implementation of `ResourceSet` is not general enough
    | 
   ::: D:\Programming\legion\src\internals\systems\resources.rs:99:1
    |
99  | / pub trait ResourceSet<'a> {
100 | |     /// The resource reference returned during a fetch.
101 | |     type Result: 'a;
102 | |
...   |
121 | |     }
122 | | }
    | |_- trait `ResourceSet` defined here
    |
    = note: `legion::internals::query::view::system_resources_view::SystemResourcesView<TestSystemResources<'_>>` must implement `ResourceSet<'0>`, for any lifetime `'0`...
    = note: ...but `legion::internals::query::view::system_resources_view::SystemResourcesView<TestSystemResources<'_>>` actually implements `ResourceSet<'1>`, for some specific lifetime `'1`
```

I hope this change won't cause any troubles. I wasn't able to come up with an example when resources can be not static in Legion.

2. ConsConcat

I've added `ConsConcat` to the codebase, but it turned out that I didn't need it for my implementation eventually... :) But it works, I was even able to flatten SystemResources to pass their members along with other resources. I figured `ConsPrepend` isn't used anywhere as well, probably they can make friends, lol.

## Status
**This pull request is in a draft state.** There are some obvious TODOs:
- [ ] Documentation and examples
- [ ] Improving error handling to match the `codegen` level of reporting errors to a user

I'm totally going to work on those if it's decided that this feature is something that would fit legion and there are no major oversights in the implementation.

