### PR TITLE
Implement Debug for Schedule, Executor and other subtypes

### DIFF
--- a/src/internals/systems/schedule.rs
+++ b/src/internals/systems/schedule.rs
@@ -122,7 +122,7 @@ impl SystemBox {
 
 impl Debug for SystemBox {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        // Safety: ???
+        // Safety: we have &self access, and if anyone else is mutably accessing this data concurrently via another &self, it is their responsibility to ensure that they are not beaking aliasing rules
         unsafe { Debug::fmt(&self.get().name(), f) }
     }
 }


### PR DESCRIPTION
This is an attempt to implement #198. I've followed the guidelines for the `Debug` trait relatively strictly, so it mostly shows the exact internal state of the various types. I could make some of it a bit more clean and easy to read, for example by grouping the values of `Executor` by index, or showing only the system names instead of the full `SystemId`, but I first wanted some feedback on whether such a deviation from standard `Debug` output would be ok.

I introduced an instance of `unsafe` in the `SystemBox` implementation. I don't know if that is sound, that should be verified by someone who knows better.

Perhaps implementing this using the `Debug` trait is the wrong approach here, I just went with that because the original issue described it that way.