### PR TITLE
Adds CustomEntitySerializer to the public API

### DIFF
--- a/src/internals/serialize/mod.rs
+++ b/src/internals/serialize/mod.rs
@@ -63,6 +63,10 @@ pub enum UnknownType {
 
 /// Describes how to serialize and deserialize a runtime `Entity` ID.
 pub trait CustomEntitySerializer {
+    /// The type used for serialized Entity IDs. Developers should be aware of their
+    /// serialization/deserialization use-cases as well as world-merge use cases when picking a
+    /// SerializedID, as the SerializedId type must identify unique entities across world
+    /// serialization/deserialization cycles as well as across world merges.
     type SerializedID: serde::Serialize + for<'a> serde::Deserialize<'a>;
     /// Constructs the serializable representation of `Entity`
     fn to_serialized(&mut self, entity: Entity) -> Self::SerializedID;

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -36,7 +36,8 @@ pub use crate::internals::serialize::{
     de::WorldDeserializer,
     id::{Canon, EntityName, EntitySerializer},
     ser::{SerializableWorld, WorldSerializer},
-    AutoTypeKey, DeserializeIntoWorld, DeserializeNewWorld, Registry, TypeKey, UnknownType,
+    AutoTypeKey, CustomEntitySerializer, DeserializeIntoWorld, DeserializeNewWorld, Registry,
+    TypeKey, UnknownType,
 };
 
 #[cfg(feature = "type-uuid")]


### PR DESCRIPTION
This enables `serialize::Registry` to take different `Entity`<->`SerializedID` maps than the default (`Canon`).

I'm trying to access `Entity`<->`SerializedID` maps outside of just the registry, which isn't supported by the `Canon` implementation, which is the trigger for opening this pull request. Looking at the code though, I think the intention was to make this trait public anyways.