### PR TITLE
adds `EntityFilterTuple` to the public API

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -91,7 +91,7 @@ pub use crate::internals::query::{
         or::Or,
         passthrough::Passthrough,
         try_component::TryComponentFilter,
-        DynamicFilter, EntityFilter, FilterResult, GroupMatcher, LayoutFilter,
+        DynamicFilter, EntityFilter, EntityFilterTuple, FilterResult, GroupMatcher, LayoutFilter,
     },
     view::{
         read::Read, try_read::TryRead, try_write::TryWrite, write::Write, DefaultFilter, Fetch,


### PR DESCRIPTION
Adding `EntityFilterTuple` to the public API enables complex queries to be stored in application data structures. I'm trying to create a query that has a chain of `Or` filters tied to `maybe_changed::<component_type>()` filters. I want this query to be stored in a data structure such that I can check if I should serialize the world or not after executing my schedule. As-is, I can't because the final query type contains `EntityFilterTuple`.