### PR TITLE
Some rearranging of serialize/deserialize code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 default = ["parallel", "serialize", "crossbeam-events", "codegen"]
 parallel = ["rayon"]
 extended-tuple-impls = []
-serialize = ["serde", "erased-serde", "uuid/serde"]
+serialize = ["serde", "erased-serde", "uuid/serde", "scoped-tls-hkt"]
 crossbeam-events = ["crossbeam-channel"]
 codegen = ["legion_codegen"]
 stdweb = ["uuid/stdweb"]
@@ -34,6 +34,7 @@ thiserror = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 rayon = { version = "1.4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
+scoped-tls-hkt = { version = "0.1", optional = true }
 erased-serde = { version = "0.3", optional = true }
 crossbeam-channel = {version ="0.4", optional = true}
 

--- a/src/internals/serialize/de.rs
+++ b/src/internals/serialize/de.rs
@@ -2,7 +2,7 @@
 
 use super::{
     archetypes::de::ArchetypeLayoutDeserializer, entities::de::EntitiesLayoutDeserializer,
-    id::run_as_context, EntitySerializer, UnknownType, WorldField,
+    id::ENTITY_SERIALIZER, EntitySerializer, UnknownType, WorldField,
 };
 use crate::{
     internals::{
@@ -93,7 +93,7 @@ impl<'a, 'de, W: WorldDeserializer, E: EntitySerializer> Visitor<'de> for WorldV
         let world_deserializer = self.world_deserializer;
         let world_inner = &mut world;
         let hoist_ref_inner = &hoist_ref;
-        run_as_context(self.entity_serializer, || {
+        ENTITY_SERIALIZER.set(self.entity_serializer, || {
             let map = map_hoist.take().unwrap();
             hoist_ref_inner.set(Some(run(world_deserializer, *world_inner, map)));
         });

--- a/src/internals/serialize/de.rs
+++ b/src/internals/serialize/de.rs
@@ -41,17 +41,15 @@ pub trait WorldDeserializer {
         type_id: ComponentTypeId,
         deserializer: D,
     ) -> Result<Box<[u8]>, D::Error>;
-
-    /// Calls `callback` with the Entity ID serializer
-    fn with_entity_serializer(&self, callback: &mut dyn FnMut(&dyn EntitySerializer));
 }
 
-pub struct WorldVisitor<'a, W: WorldDeserializer> {
-    pub world_deserializer: &'a W,
+pub struct WorldVisitor<'a, W: WorldDeserializer, E: EntitySerializer> {
     pub world: &'a mut World,
+    pub world_deserializer: &'a W,
+    pub entity_serializer: &'a E,
 }
 
-impl<'a, 'de, W: WorldDeserializer> Visitor<'de> for WorldVisitor<'a, W> {
+impl<'a, 'de, W: WorldDeserializer, E: EntitySerializer> Visitor<'de> for WorldVisitor<'a, W, E> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -93,13 +91,11 @@ impl<'a, 'de, W: WorldDeserializer> Visitor<'de> for WorldVisitor<'a, W> {
         let mut world = self.world;
         let mut map_hoist = Some(map);
         let world_deserializer = self.world_deserializer;
-        world_deserializer.with_entity_serializer(&mut |canon| {
-            let world_inner = &mut world;
-            let hoist_ref_inner = &hoist_ref;
-            run_as_context(canon, || {
-                let map = map_hoist.take().unwrap();
-                hoist_ref_inner.set(Some(run(world_deserializer, *world_inner, map)));
-            })
+        let world_inner = &mut world;
+        let hoist_ref_inner = &hoist_ref;
+        run_as_context(self.entity_serializer, || {
+            let map = map_hoist.take().unwrap();
+            hoist_ref_inner.set(Some(run(world_deserializer, *world_inner, map)));
         });
         hoist.into_inner().unwrap()
     }

--- a/src/internals/serialize/de.rs
+++ b/src/internals/serialize/de.rs
@@ -2,13 +2,14 @@
 
 use super::{
     archetypes::de::ArchetypeLayoutDeserializer, entities::de::EntitiesLayoutDeserializer,
-    id::ENTITY_SERIALIZER, EntitySerializer, UnknownType, WorldField,
+    EntitySerializer, UnknownType, WorldField,
 };
 use crate::{
     internals::{
         storage::{archetype::EntityLayout, component::ComponentTypeId},
         world::World,
     },
+    serialize::set_entity_serializer,
     storage::UnknownComponentWriter,
 };
 use serde::{
@@ -93,7 +94,7 @@ impl<'a, 'de, W: WorldDeserializer, E: EntitySerializer> Visitor<'de> for WorldV
         let world_deserializer = self.world_deserializer;
         let world_inner = &mut world;
         let hoist_ref_inner = &hoist_ref;
-        ENTITY_SERIALIZER.set(self.entity_serializer, || {
+        set_entity_serializer(self.entity_serializer, || {
             let map = map_hoist.take().unwrap();
             hoist_ref_inner.set(Some(run(world_deserializer, *world_inner, map)));
         });

--- a/src/internals/serialize/id.rs
+++ b/src/internals/serialize/id.rs
@@ -1,6 +1,6 @@
 use crate::{internals::entity::EntityHasher, world::Allocate, Entity};
+use scoped_tls_hkt::scoped_thread_local;
 use serde::{Deserialize, Serialize, Serializer};
-use std::cell::RefCell;
 use std::collections::{hash_map::Entry, HashMap};
 use thiserror::Error;
 use uuid::Uuid;
@@ -8,7 +8,7 @@ use uuid::Uuid;
 /// Describes how to serialize and deserialize a runtime `Entity` ID.
 ///
 /// This trait is automatically implemented for types that implement [`CustomEntitySerializer`].
-pub trait EntitySerializer {
+pub trait EntitySerializer: 'static {
     /// Serializes an `Entity` by constructing the serializable representation
     /// and passing it into `serialize_fn`.
     fn serialize(&self, entity: Entity, serialize_fn: &mut dyn FnMut(&dyn erased_serde::Serialize));
@@ -40,7 +40,7 @@ pub trait CustomEntitySerializer {
 
 impl<T> EntitySerializer for T
 where
-    T: CustomEntitySerializer,
+    T: CustomEntitySerializer + 'static,
 {
     fn serialize(
         &self,
@@ -63,47 +63,26 @@ where
     }
 }
 
-thread_local! {
-    static SERIALIZER: RefCell<Option<&'static dyn EntitySerializer>> = RefCell::new(None);
-}
-
-/// Runs the provided function with this canon as context for Entity (de)serialization.
-pub fn run_as_context<F: FnOnce() -> R, R>(context: &dyn EntitySerializer, f: F) -> R {
-    struct SerializerGuard<'a> {
-        cell: &'a RefCell<Option<&'static dyn EntitySerializer>>,
-        prev: Option<&'static dyn EntitySerializer>,
-    }
-
-    impl Drop for SerializerGuard<'_> {
-        fn drop(&mut self) {
-            // swap context back out of TLS, putting back what we took out.
-            let mut existing = self.cell.borrow_mut();
-            *existing = self.prev;
-        }
-    }
-
-    SERIALIZER.with(|cell| {
-        // swap context into TLS
-        let _serializer_guard = {
-            let mut existing = cell.borrow_mut();
-            // Safety? Hmm
-            // This &'static reference is only stored in the TLS for the duration of this function,
-            // meaning it will be valid for all TLS uses as long as it's not copied anywhere else.
-            // Can't express this lifetime in a TLS-static, so that's why this unsafe block needs to exist.
-            //
-            // If `f` unwinds, the SerializerGuard destructor will restore the previous value of
-            // SERIALIZER, so there's no risk of leaving a dangling reference.
-            let hacked_context = unsafe {
-                core::mem::transmute::<&dyn EntitySerializer, &'static dyn EntitySerializer>(
-                    context,
-                )
-            };
-            let prev = std::mem::replace(&mut *existing, Some(hacked_context));
-            SerializerGuard { cell, prev }
-        };
-
-        (f)()
-    })
+scoped_thread_local! {
+    /// The [`EntitySerializer`] currently being used to serialize or deserialize [`Entity`] IDs.
+    ///
+    /// This is set automatically when serializing or deserializing a [`World`]. When serializing or
+    /// deserializing values outside a `World`, this needs to be set manually, passing in a reference
+    /// to the `EntitySerializer` and a closure that does the serializing/deserializing.
+    /// ```
+    /// # use legion::*;
+    /// # use legion::serialize::{Canon, ENTITY_SERIALIZER};
+    /// # let mut world = World::default();
+    /// # #[derive(serde::Serialize, serde::Deserialize)]
+    /// # struct ContainsEntity(Entity);
+    /// # let contains_entity = ContainsEntity(world.push(()));
+    ///
+    /// let entity_serializer = Canon::default();
+    /// ENTITY_SERIALIZER.set(&entity_serializer, || {
+    ///     serde_json::to_value(contains_entity).unwrap()
+    /// });
+    /// ```
+    pub static ENTITY_SERIALIZER: dyn EntitySerializer
 }
 
 impl Serialize for Entity {
@@ -111,22 +90,18 @@ impl Serialize for Entity {
     where
         S: Serializer,
     {
-        SERIALIZER.with(|cell| {
-            let mut entity_serializer = cell.borrow_mut();
+        ENTITY_SERIALIZER.with(|entity_serializer| {
             let mut result = None;
             let mut serializer = Some(serializer);
             let result_ref = &mut result;
-            entity_serializer
-                .as_mut()
-                .expect("No entity serializer set")
-                .serialize(*self, &mut move |serializable| {
-                    *result_ref = Some(erased_serde::serialize(
-                        serializable,
-                        serializer
-                            .take()
-                            .expect("serialize can only be called once"),
-                    ));
-                });
+            entity_serializer.serialize(*self, &mut move |serializable| {
+                *result_ref = Some(erased_serde::serialize(
+                    serializable,
+                    serializer
+                        .take()
+                        .expect("serialize can only be called once"),
+                ));
+            });
             result.unwrap()
         })
     }
@@ -138,12 +113,9 @@ impl<'de> Deserialize<'de> for Entity {
         D: serde::Deserializer<'de>,
     {
         use serde::de::Error;
-        SERIALIZER.with(|cell| {
+        ENTITY_SERIALIZER.with(|entity_serializer| {
             let mut deserializer = erased_serde::Deserializer::erase(deserializer);
-            let mut entity_serializer = cell.borrow_mut();
             entity_serializer
-                .as_mut()
-                .expect("No entity serializer set")
                 .deserialize(&mut deserializer)
                 .map_err(D::Error::custom)
         })

--- a/src/internals/serialize/mod.rs
+++ b/src/internals/serialize/mod.rs
@@ -562,7 +562,7 @@ mod test {
     fn run_as_context_panic() {
         std::panic::catch_unwind(|| {
             let entity_serializer = Canon::default();
-            super::id::run_as_context(&entity_serializer, || panic!());
+            super::id::ENTITY_SERIALIZER.set(&entity_serializer, || panic!());
         })
         .unwrap_err();
 

--- a/src/internals/serialize/mod.rs
+++ b/src/internals/serialize/mod.rs
@@ -13,10 +13,10 @@ use crate::{
     Entity,
 };
 use de::{WorldDeserializer, WorldVisitor};
-use id::{Canon, EntitySerializer};
+use id::EntitySerializer;
 use ser::WorldSerializer;
 use serde::{de::DeserializeSeed, Serializer};
-use std::{collections::HashMap, hash::Hash, marker::PhantomData, sync::Arc};
+use std::{collections::HashMap, hash::Hash, marker::PhantomData};
 
 pub mod archetypes;
 pub mod de;
@@ -83,13 +83,11 @@ pub trait CustomEntitySerializer {
 ///
 /// See the [legion_typeuuid crate](https://github.com/TomGillen/legion_typeuuid) for an example
 /// of a type key which is stable between compiles.
-pub struct Registry<T, S = Canon>
+pub struct Registry<T>
 where
     T: TypeKey,
-    S: CustomEntitySerializer + 'static,
 {
     _phantom_t: PhantomData<T>,
-    _phantom_s: PhantomData<S>,
     missing: UnknownType,
     serialize_fns: HashMap<
         ComponentTypeId,
@@ -102,23 +100,19 @@ where
         ),
     >,
     constructors: HashMap<T, (ComponentTypeId, fn(&mut EntityLayout))>,
-    canon: Arc<parking_lot::RwLock<S>>,
 }
 
-impl<T, S> Registry<T, S>
+impl<T> Registry<T>
 where
     T: TypeKey,
-    S: CustomEntitySerializer + 'static,
 {
     /// Constructs a new registry.
-    pub fn new(canon: Arc<parking_lot::RwLock<S>>) -> Self {
+    pub fn new() -> Self {
         Self {
             missing: UnknownType::Error,
             serialize_fns: HashMap::new(),
             constructors: HashMap::new(),
-            canon,
             _phantom_t: PhantomData,
-            _phantom_s: PhantomData,
         }
     }
 
@@ -194,30 +188,41 @@ where
     }
 
     /// Constructs a serde::DeserializeSeed which will deserialize into an existing world.
-    pub fn as_deserialize_into_world<'a>(
+    pub fn as_deserialize_into_world<'a, E: EntitySerializer>(
         &'a self,
         world: &'a mut World,
-    ) -> DeserializeIntoWorld<'a, Self> {
-        DeserializeIntoWorld(&self, world)
+        entity_serializer: &'a E,
+    ) -> DeserializeIntoWorld<'a, Self, E> {
+        DeserializeIntoWorld {
+            world,
+            world_deserializer: self,
+            entity_serializer,
+        }
     }
 
     /// Constructs a serde::DeserializeSeed which will deserialize into a new world.
-    pub fn as_deserialize(&self) -> DeserializeNewWorld<'_, Self> {
-        DeserializeNewWorld(&self)
+    pub fn as_deserialize<'a, E: EntitySerializer>(
+        &'a self,
+        entity_serializer: &'a E,
+    ) -> DeserializeNewWorld<'a, Self, E> {
+        DeserializeNewWorld {
+            world_deserializer: self,
+            entity_serializer,
+        }
     }
 }
 
-impl<T, S> Default for Registry<T, S>
+impl<T> Default for Registry<T>
 where
     T: TypeKey,
-    S: CustomEntitySerializer + Default + 'static,
 {
+    #[inline]
     fn default() -> Self {
-        Self::new(Arc::new(parking_lot::RwLock::new(S::default())))
+        Self::new()
     }
 }
 
-impl<S: CustomEntitySerializer + 'static> EntitySerializer for &parking_lot::RwLock<S> {
+impl<S: CustomEntitySerializer + 'static> EntitySerializer for parking_lot::RwLock<S> {
     fn serialize(
         &self,
         entity: Entity,
@@ -241,10 +246,9 @@ impl<S: CustomEntitySerializer + 'static> EntitySerializer for &parking_lot::RwL
     }
 }
 
-impl<T, S> WorldSerializer for Registry<T, S>
+impl<T> WorldSerializer for Registry<T>
 where
     T: TypeKey,
-    S: CustomEntitySerializer + 'static,
 {
     type TypeId = T;
 
@@ -308,16 +312,11 @@ where
             panic!();
         }
     }
-    fn with_entity_serializer(&self, callback: &mut dyn FnMut(&dyn EntitySerializer)) {
-        let canon_ref = &*self.canon;
-        callback(&canon_ref);
-    }
 }
 
-impl<T, S> WorldDeserializer for Registry<T, S>
+impl<T> WorldDeserializer for Registry<T>
 where
     T: TypeKey,
-    S: CustomEntitySerializer + 'static,
 {
     type TypeId = T;
 
@@ -364,10 +363,6 @@ where
             //Err(D::Error::custom("unrecognized component type"))
             panic!()
         }
-    }
-    fn with_entity_serializer(&self, callback: &mut dyn FnMut(&dyn EntitySerializer)) {
-        let canon_ref = &*self.canon;
-        callback(&canon_ref);
     }
 }
 
@@ -425,11 +420,20 @@ impl<'a, 'de, T: Component + for<'b> serde::de::Deserialize<'b>> serde::de::Dese
     }
 }
 
-/// Wraps a [WorldDeserializer](de/trait.WorldDeserializer.html) and a world and implements
+/// Wraps a [WorldDeserializer](trait.WorldDeserializer.html) and a world and implements
 /// `serde::DeserializeSeed` for deserializing into the world.
-pub struct DeserializeIntoWorld<'a, T: WorldDeserializer>(pub &'a T, pub &'a mut World);
+pub struct DeserializeIntoWorld<'a, W: WorldDeserializer, E: EntitySerializer> {
+    /// The [World](../world/struct.World.html) to deserialize into.
+    pub world: &'a mut World,
+    /// The [WorldDeserializer](trait.WorldDeserializer.html) to use.
+    pub world_deserializer: &'a W,
+    /// The [EntitySerializer](trait.EntitySerializer.html) to use.
+    pub entity_serializer: &'a E,
+}
 
-impl<'a, 'de, W: WorldDeserializer> DeserializeSeed<'de> for DeserializeIntoWorld<'a, W> {
+impl<'a, 'de, W: WorldDeserializer, E: EntitySerializer> DeserializeSeed<'de>
+    for DeserializeIntoWorld<'a, W, E>
+{
     type Value = ();
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -437,17 +441,25 @@ impl<'a, 'de, W: WorldDeserializer> DeserializeSeed<'de> for DeserializeIntoWorl
         D: serde::Deserializer<'de>,
     {
         deserializer.deserialize_map(WorldVisitor {
-            world_deserializer: self.0,
-            world: self.1,
+            world: self.world,
+            world_deserializer: self.world_deserializer,
+            entity_serializer: self.entity_serializer,
         })
     }
 }
 
-/// Wraps a [WorldDeserializer](de/trait.WorldDeserializer.html) and a universe and implements
+/// Wraps a [WorldDeserializer](de/trait.WorldDeserializer.html) and a world and implements
 /// `serde::DeserializeSeed` for deserializing into a new world.
-pub struct DeserializeNewWorld<'a, T: WorldDeserializer>(pub &'a T);
+pub struct DeserializeNewWorld<'a, W: WorldDeserializer, E: EntitySerializer> {
+    /// The [WorldDeserializer](trait.WorldDeserializer.html) to use.
+    pub world_deserializer: &'a W,
+    /// The [EntitySerializer](trait.EntitySerializer.html) to use.
+    pub entity_serializer: &'a E,
+}
 
-impl<'a, 'de, W: WorldDeserializer> DeserializeSeed<'de> for DeserializeNewWorld<'a, W> {
+impl<'a, 'de, W: WorldDeserializer, E: EntitySerializer> DeserializeSeed<'de>
+    for DeserializeNewWorld<'a, W, E>
+{
     type Value = World;
 
     fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
@@ -455,7 +467,12 @@ impl<'a, 'de, W: WorldDeserializer> DeserializeSeed<'de> for DeserializeNewWorld
         D: serde::Deserializer<'de>,
     {
         let mut world = World::default();
-        DeserializeIntoWorld(self.0, &mut world).deserialize(deserializer)?;
+        DeserializeIntoWorld {
+            world: &mut world,
+            world_deserializer: self.world_deserializer,
+            entity_serializer: self.entity_serializer,
+        }
+        .deserialize(deserializer)?;
         Ok(world)
     }
 }
@@ -469,10 +486,11 @@ enum WorldField {
 
 #[cfg(test)]
 mod test {
-    use super::{Canon, Registry};
+    use super::Registry;
     use crate::internals::{
         entity::Entity,
         query::filter::filter_fns::any,
+        serialize::id::Canon,
         world::{EntityStore, World},
     };
 
@@ -497,17 +515,23 @@ mod test {
             (8usize, 8isize, EntityRef(entity)),
         ])[0];
 
+        let entity_serializer = parking_lot::RwLock::new(Canon::default());
         let mut registry = Registry::<String>::default();
         registry.register::<usize>("usize".to_string());
         registry.register::<bool>("bool".to_string());
         registry.register::<isize>("isize".to_string());
         registry.register::<EntityRef>("entity_ref".to_string());
 
-        let json = serde_json::to_value(&world.as_serializable(any(), &registry)).unwrap();
+        let json =
+            serde_json::to_value(&world.as_serializable(any(), &registry, &entity_serializer))
+                .unwrap();
         println!("{:#}", json);
 
         use serde::de::DeserializeSeed;
-        let world: World = registry.as_deserialize().deserialize(json).unwrap();
+        let world: World = registry
+            .as_deserialize(&entity_serializer)
+            .deserialize(json)
+            .unwrap();
         let entry = world.entry_ref(entity).unwrap();
         assert_eq!(entry.get_component::<usize>().unwrap(), &1usize);
         assert_eq!(entry.get_component::<bool>().unwrap(), &false);
@@ -543,12 +567,15 @@ mod test {
             (8usize, 8isize),
         ]);
 
+        let entity_serializer = parking_lot::RwLock::new(Canon::default());
         let mut registry = Registry::<i32>::default();
         registry.register::<usize>(1);
         registry.register::<bool>(2);
         registry.register::<isize>(3);
 
-        let encoded = bincode::serialize(&world.as_serializable(any(), &registry)).unwrap();
+        let encoded =
+            bincode::serialize(&world.as_serializable(any(), &registry, &entity_serializer))
+                .unwrap();
 
         use bincode::config::Options;
         use serde::de::DeserializeSeed;
@@ -559,7 +586,7 @@ mod test {
                 .allow_trailing_bytes(),
         );
         let world: World = registry
-            .as_deserialize()
+            .as_deserialize(&entity_serializer)
             .deserialize(&mut deserializer)
             .unwrap();
         let entity = world.entry_ref(entity).unwrap();
@@ -573,11 +600,8 @@ mod test {
     #[test]
     fn run_as_context_panic() {
         std::panic::catch_unwind(|| {
-            let registry = Registry::<i32>::default();
-
-            super::WorldSerializer::with_entity_serializer(&registry, &mut |canon| {
-                super::id::run_as_context(canon, || panic!());
-            });
+            let entity_serializer = parking_lot::RwLock::new(Canon::default());
+            super::id::run_as_context(&entity_serializer, || panic!());
         })
         .unwrap_err();
 
@@ -606,24 +630,29 @@ mod test {
             (8usize, 8isize, EntityRef(entity)),
         ])[0];
 
-        let locked_canon_ref = std::sync::Arc::new(parking_lot::RwLock::new(Canon::default()));
-        let mut registry = Registry::<String>::new(locked_canon_ref.clone());
+        let entity_serializer = parking_lot::RwLock::new(Canon::default());
+        let mut registry = Registry::<String>::new();
         registry.register::<usize>("usize".to_string());
         registry.register::<bool>("bool".to_string());
         registry.register::<isize>("isize".to_string());
         registry.register::<EntityRef>("entity_ref".to_string());
 
-        let json = serde_json::to_value(&world1.as_serializable(any(), &registry)).unwrap();
+        let json =
+            serde_json::to_value(&world1.as_serializable(any(), &registry, &entity_serializer))
+                .unwrap();
         println!("{:#}", json);
         // Need to drop our read access to the canon before registry.as_deserialize will work,
         // otherwise it will hang trying to acquire write access to the canon.
         {
-            let canon = locked_canon_ref.read();
+            let canon = entity_serializer.read();
             let entityname = canon.get_name(entity).unwrap();
             assert_eq!(canon.get_id(&entityname).unwrap(), entity);
         }
         use serde::de::DeserializeSeed;
-        let world2: World = registry.as_deserialize().deserialize(json).unwrap();
+        let world2: World = registry
+            .as_deserialize(&entity_serializer)
+            .deserialize(json)
+            .unwrap();
         let entry = world2.entry_ref(entity).unwrap();
         assert_eq!(entry.get_component::<usize>().unwrap(), &1usize);
         assert_eq!(entry.get_component::<bool>().unwrap(), &false);

--- a/src/internals/serialize/mod.rs
+++ b/src/internals/serialize/mod.rs
@@ -451,7 +451,7 @@ mod test {
     use crate::internals::{
         entity::Entity,
         query::filter::filter_fns::any,
-        serialize::id::Canon,
+        serialize::id::{set_entity_serializer, Canon},
         world::{EntityStore, World},
     };
 
@@ -562,7 +562,7 @@ mod test {
     fn run_as_context_panic() {
         std::panic::catch_unwind(|| {
             let entity_serializer = Canon::default();
-            super::id::ENTITY_SERIALIZER.set(&entity_serializer, || panic!());
+            set_entity_serializer(&entity_serializer, || panic!());
         })
         .unwrap_err();
 

--- a/src/internals/serialize/ser.rs
+++ b/src/internals/serialize/ser.rs
@@ -42,47 +42,61 @@ pub trait WorldSerializer {
         archetype: ArchetypeIndex,
         serializer: S,
     ) -> Result<S::Ok, S::Error>;
-
-    /// Calls `callback` with the Entity ID serializer
-    fn with_entity_serializer(&self, callback: &mut dyn FnMut(&dyn EntitySerializer));
 }
 
 /// A serializable representation of a world.
-pub struct SerializableWorld<'a, F: LayoutFilter, W: WorldSerializer> {
+pub struct SerializableWorld<'a, F: LayoutFilter, W: WorldSerializer, E: EntitySerializer> {
     world: &'a World,
     filter: F,
     world_serializer: &'a W,
+    entity_serializer: &'a E,
 }
 
-impl<'a, F: LayoutFilter, W: WorldSerializer> SerializableWorld<'a, F, W> {
-    pub(crate) fn new(world: &'a World, filter: F, world_serializer: &'a W) -> Self {
+impl<'a, F: LayoutFilter, W: WorldSerializer, E: EntitySerializer> SerializableWorld<'a, F, W, E> {
+    pub(crate) fn new(
+        world: &'a World,
+        filter: F,
+        world_serializer: &'a W,
+        entity_serializer: &'a E,
+    ) -> Self {
         Self {
             world,
             filter,
             world_serializer,
+            entity_serializer,
         }
     }
 }
 
-impl<'a, F: LayoutFilter, W: WorldSerializer> Serialize for SerializableWorld<'a, F, W> {
+impl<'a, F: LayoutFilter, W: WorldSerializer, E: EntitySerializer> Serialize
+    for SerializableWorld<'a, F, W, E>
+{
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serialize_world(serializer, self.world, &self.filter, self.world_serializer)
+        serialize_world(
+            serializer,
+            self.world,
+            &self.filter,
+            self.world_serializer,
+            self.entity_serializer,
+        )
     }
 }
 
-fn serialize_world<S, F, W>(
+fn serialize_world<S, F, W, E>(
     serializer: S,
     world: &World,
     filter: &F,
     world_serializer: &W,
+    entity_serializer: &E,
 ) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
     F: LayoutFilter,
     W: WorldSerializer,
+    E: EntitySerializer,
 {
     let human_readable = serializer.is_human_readable();
     let mut root = serializer.serialize_map(Some(1))?;
@@ -90,32 +104,32 @@ where
     let mut hoist = core::cell::Cell::new(None);
     let hoist_ref = &mut hoist;
     let root_ref = &mut root;
-    world_serializer.with_entity_serializer(&mut |canon| {
-        run_as_context(canon, || {
-            let result = if human_readable {
-                // serialize per-entity representation
-                root_ref.serialize_entry(
-                    &WorldField::Entities,
-                    &EntitiesLayoutSerializer {
-                        world_serializer,
-                        world,
-                        filter,
-                    },
-                )
-            } else {
-                // serialize machine-optimised representation
-                root_ref.serialize_entry(
-                    &WorldField::Packed,
-                    &ArchetypeLayoutSerializer {
-                        world_serializer,
-                        world,
-                        filter,
-                    },
-                )
-            };
-            hoist_ref.set(Some(result));
-        })
+
+    run_as_context(entity_serializer, || {
+        let result = if human_readable {
+            // serialize per-entity representation
+            root_ref.serialize_entry(
+                &WorldField::Entities,
+                &EntitiesLayoutSerializer {
+                    world_serializer,
+                    world,
+                    filter,
+                },
+            )
+        } else {
+            // serialize machine-optimised representation
+            root_ref.serialize_entry(
+                &WorldField::Packed,
+                &ArchetypeLayoutSerializer {
+                    world_serializer,
+                    world,
+                    filter,
+                },
+            )
+        };
+        hoist_ref.set(Some(result));
     });
+
     hoist.into_inner().unwrap()?;
     root.end()
 }

--- a/src/internals/serialize/ser.rs
+++ b/src/internals/serialize/ser.rs
@@ -2,10 +2,11 @@
 
 use super::{
     archetypes::ser::ArchetypeLayoutSerializer, entities::ser::EntitiesLayoutSerializer,
-    id::ENTITY_SERIALIZER, EntitySerializer, UnknownType, WorldField,
+    EntitySerializer, UnknownType, WorldField,
 };
 use crate::{
     internals::{query::filter::LayoutFilter, storage::component::ComponentTypeId, world::World},
+    serialize::set_entity_serializer,
     storage::{ArchetypeIndex, UnknownComponentStorage},
 };
 use serde::ser::{Serialize, SerializeMap, Serializer};
@@ -105,7 +106,7 @@ where
     let hoist_ref = &mut hoist;
     let root_ref = &mut root;
 
-    ENTITY_SERIALIZER.set(entity_serializer, || {
+    set_entity_serializer(entity_serializer, || {
         let result = if human_readable {
             // serialize per-entity representation
             root_ref.serialize_entry(

--- a/src/internals/serialize/ser.rs
+++ b/src/internals/serialize/ser.rs
@@ -2,7 +2,7 @@
 
 use super::{
     archetypes::ser::ArchetypeLayoutSerializer, entities::ser::EntitiesLayoutSerializer,
-    id::run_as_context, EntitySerializer, UnknownType, WorldField,
+    id::ENTITY_SERIALIZER, EntitySerializer, UnknownType, WorldField,
 };
 use crate::{
     internals::{query::filter::LayoutFilter, storage::component::ComponentTypeId, world::World},
@@ -105,7 +105,7 @@ where
     let hoist_ref = &mut hoist;
     let root_ref = &mut root;
 
-    run_as_context(entity_serializer, || {
+    ENTITY_SERIALIZER.set(entity_serializer, || {
         let result = if human_readable {
             // serialize per-entity representation
             root_ref.serialize_entry(

--- a/src/internals/world.rs
+++ b/src/internals/world.rs
@@ -806,7 +806,7 @@ impl World {
     /// registry.register::<bool>("bool".to_string());
     ///
     /// // serialize entities with the `Position` component
-    /// let entity_serializer = parking_lot::RwLock::new(Canon::default());
+    /// let entity_serializer = Canon::default();
     /// let json = serde_json::to_value(&world.as_serializable(component::<Position>(), &registry, &entity_serializer)).unwrap();
     /// println!("{:#}", json);
     ///

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -33,7 +33,7 @@
 
 pub use crate::internals::serialize::{
     de::WorldDeserializer,
-    id::{Canon, CustomEntitySerializer, EntityName, EntitySerializer, ENTITY_SERIALIZER},
+    id::{set_entity_serializer, Canon, CustomEntitySerializer, EntityName, EntitySerializer},
     ser::{SerializableWorld, WorldSerializer},
     AutoTypeKey, DeserializeIntoWorld, DeserializeNewWorld, Registry, TypeKey, UnknownType,
 };

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -36,7 +36,7 @@
 
 pub use crate::internals::serialize::{
     de::WorldDeserializer,
-    id::{Canon, CustomEntitySerializer, EntityName, EntitySerializer},
+    id::{Canon, CustomEntitySerializer, EntityName, EntitySerializer, ENTITY_SERIALIZER},
     ser::{SerializableWorld, WorldSerializer},
     AutoTypeKey, DeserializeIntoWorld, DeserializeNewWorld, Registry, TypeKey, UnknownType,
 };

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -14,6 +14,7 @@
 //! Serializing all entities with a `Position` component to JSON.
 //! ```
 //! # use legion::*;
+//! # use legion::serialize::Canon;
 //! # let world = World::default();
 //! # #[derive(serde::Serialize, serde::Deserialize)]
 //! # struct Position;
@@ -24,12 +25,13 @@
 //! registry.register::<bool>("bool".to_string());
 //!
 //! // serialize entities with the `Position` component
-//! let json = serde_json::to_value(&world.as_serializable(component::<Position>(), &registry)).unwrap();
+//! let entity_serializer = parking_lot::RwLock::new(Canon::default());
+//! let json = serde_json::to_value(&world.as_serializable(component::<Position>(), &registry, &entity_serializer)).unwrap();
 //! println!("{:#}", json);
 //!
 //! // registries are also serde deserializers
 //! use serde::de::DeserializeSeed;
-//! let world: World = registry.as_deserialize().deserialize(json).unwrap();
+//! let world: World = registry.as_deserialize(&entity_serializer).deserialize(json).unwrap();
 //! ```
 
 pub use crate::internals::serialize::{

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -25,7 +25,7 @@
 //! registry.register::<bool>("bool".to_string());
 //!
 //! // serialize entities with the `Position` component
-//! let entity_serializer = parking_lot::RwLock::new(Canon::default());
+//! let entity_serializer = Canon::default();
 //! let json = serde_json::to_value(&world.as_serializable(component::<Position>(), &registry, &entity_serializer)).unwrap();
 //! println!("{:#}", json);
 //!
@@ -36,10 +36,9 @@
 
 pub use crate::internals::serialize::{
     de::WorldDeserializer,
-    id::{Canon, EntityName, EntitySerializer},
+    id::{Canon, CustomEntitySerializer, EntityName, EntitySerializer},
     ser::{SerializableWorld, WorldSerializer},
-    AutoTypeKey, CustomEntitySerializer, DeserializeIntoWorld, DeserializeNewWorld, Registry,
-    TypeKey, UnknownType,
+    AutoTypeKey, DeserializeIntoWorld, DeserializeNewWorld, Registry, TypeKey, UnknownType,
 };
 
 #[cfg(feature = "type-uuid")]


### PR DESCRIPTION
The following changes are made, some of which are breaking.

- `Canon` is moved out of `Registry` so that it's now a free-standing type. That way there's a clear separation of concerns, between handling `Entity` and handling component types.
- The `with_entity_serializer` methods on `WorldSerializer` and `WorldDeserializer` are consequently removed, while `World::as_serializable` and `Registry::as_deserialize(_into_world)` take an extra `EntitySerializer` argument.
- `Canon` now handles its locking internally, instead of having to be wrapped in a lock.
- `CustomEntitySerializer`'s methods take `&self`, possible due to the change above.
- `EntitySerializer` now has a blanket implementation for anything that implements `CustomEntitySerializer`.
- The custom `run_as_context` logic is replaced with the [`scoped-tls-hkt`](https://github.com/Diggsey/scoped-tls-hkt) crate, which does this more cleanly and is better-tested.
- The `ENTITY_SERIALIZER` variable, introduced by the change above, is made public and documented. This fixes #228.

I think that the `EntitySerializer` and `CustomEntitySerializer` traits could do with better names, but I've held off on that as I can't think of names that really work well.