### PR TITLE
Fetching a nonexistent resource prints the name of a type

### DIFF
--- a/src/internals/systems/resources.rs
+++ b/src/internals/systems/resources.rs
@@ -133,7 +133,7 @@ impl<'a, T: Resource> ResourceSet<'a> for Read<T> {
         resources
             .get(&type_id)
             .and_then(|x| x.get::<T>())
-            .unwrap_or_else(|| panic!("resource {} does not exist", type_id.name))
+            .unwrap_or_else(|| panic_nonexistent_resource(type_id))
     }
 }
 
@@ -145,8 +145,15 @@ impl<'a, T: Resource> ResourceSet<'a> for Write<T> {
         resources
             .get(&type_id)
             .and_then(|x| x.get_mut::<T>())
-            .unwrap_or_else(|| panic!("resource {} does not exist", type_id.name))
+            .unwrap_or_else(|| panic_nonexistent_resource(type_id))
     }
+}
+
+fn panic_nonexistent_resource(type_id: &ResourceTypeId) -> ! {
+    #[cfg(debug_assertions)]
+    panic!("resource {} does not exist", type_id.name);
+    #[cfg(not(debug_assertions))]
+    panic!("some resource does not exist");
 }
 
 macro_rules! resource_tuple {

--- a/src/internals/systems/resources.rs
+++ b/src/internals/systems/resources.rs
@@ -133,7 +133,7 @@ impl<'a, T: Resource> ResourceSet<'a> for Read<T> {
         resources
             .get(&type_id)
             .and_then(|x| x.get::<T>())
-            .expect("resource does not exist")
+            .unwrap_or_else(|| panic!("resource {} does not exist", type_id.name))
     }
 }
 
@@ -145,7 +145,7 @@ impl<'a, T: Resource> ResourceSet<'a> for Write<T> {
         resources
             .get(&type_id)
             .and_then(|x| x.get_mut::<T>())
-            .expect("resource does not exist")
+            .unwrap_or_else(|| panic!("resource {} does not exist", type_id.name))
     }
 }
 


### PR DESCRIPTION
To make debugging easier