### PR TITLE
Removing derivative from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ legion_codegen = { path = "codegen", version = "0.3", optional = true }
 smallvec = "1.4"
 itertools = "0.9"
 downcast-rs = "1.2"
-derivative = "2.1"
 paste = "1.0.0"
 parking_lot = "0.11"
 bit-set = "0.5"

--- a/src/internals/query/view/read.rs
+++ b/src/internals/query/view/read.rs
@@ -15,13 +15,17 @@ use crate::internals::{
     },
     subworld::ComponentAccess,
 };
-use derivative::Derivative;
 use std::{any::TypeId, marker::PhantomData, slice::Iter};
 
 /// Reads a single entity data component type from a chunk.
-#[derive(Derivative, Debug, Copy, Clone)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug, Copy, Clone)]
 pub struct Read<T>(PhantomData<*const T>);
+
+impl<T> Default for Read<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
 
 unsafe impl<T> Send for Read<T> {}
 unsafe impl<T: Sync> Sync for Read<T> {}

--- a/src/internals/query/view/try_read.rs
+++ b/src/internals/query/view/try_read.rs
@@ -15,13 +15,17 @@ use crate::internals::{
     },
     subworld::ComponentAccess,
 };
-use derivative::Derivative;
 use std::{any::TypeId, marker::PhantomData};
 
 /// Reads a single entity data component type from a chunk.
-#[derive(Derivative, Debug, Copy, Clone)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug, Copy, Clone)]
 pub struct TryRead<T>(PhantomData<*const T>);
+
+impl<T> Default for TryRead<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
 
 unsafe impl<T> Send for TryRead<T> {}
 unsafe impl<T: Sync> Sync for TryRead<T> {}

--- a/src/internals/query/view/try_write.rs
+++ b/src/internals/query/view/try_write.rs
@@ -15,13 +15,17 @@ use crate::internals::{
     },
     subworld::ComponentAccess,
 };
-use derivative::Derivative;
 use std::{any::TypeId, marker::PhantomData};
 
 /// Writes a single entity data component type from a chunk.
-#[derive(Derivative, Debug, Copy, Clone)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug, Copy, Clone)]
 pub struct TryWrite<T>(PhantomData<*const T>);
+
+impl<T> Default for TryWrite<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
 
 unsafe impl<T: Send> Send for TryWrite<T> {}
 unsafe impl<T> Sync for TryWrite<T> {}

--- a/src/internals/query/view/write.rs
+++ b/src/internals/query/view/write.rs
@@ -15,13 +15,17 @@ use crate::internals::{
     },
     subworld::ComponentAccess,
 };
-use derivative::Derivative;
 use std::{any::TypeId, marker::PhantomData, slice::Iter};
 
 /// Writes a single mutable entity data component type from a chunk.
-#[derive(Derivative, Debug, Copy, Clone)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug, Copy, Clone)]
 pub struct Write<T>(PhantomData<*const T>);
+
+impl<T> Default for Write<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
 
 unsafe impl<T: Send> Send for Write<T> {}
 unsafe impl<T> Sync for Write<T> {}

--- a/src/internals/storage/slicevec.rs
+++ b/src/internals/storage/slicevec.rs
@@ -1,17 +1,25 @@
 //! A vector of slices.
 
-use derivative::Derivative;
 use std::iter::{FusedIterator, IntoIterator};
 
 /// A vector of slices.
 ///
 /// Each slice is stored inline so as to be efficiently iterated through linearly.
-#[derive(Derivative, Debug)]
-#[derivative(Default(bound = ""))]
+#[derive(Debug)]
 pub struct SliceVec<T> {
     data: Vec<T>,
     counts: Vec<usize>,
     indices: Vec<usize>,
+}
+
+impl<T> Default for SliceVec<T> {
+    fn default() -> Self {
+        Self {
+            data: Vec::new(),
+            counts: Vec::new(),
+            indices: Vec::new(),
+        }
+    }
 }
 
 impl<T> SliceVec<T> {

--- a/src/internals/systems/command.rs
+++ b/src/internals/systems/command.rs
@@ -17,13 +17,14 @@ use crate::{
     },
     world::Allocate,
 };
-use derivative::Derivative;
 use smallvec::SmallVec;
-use std::ops::Range;
 use std::{
+    any::type_name,
     collections::VecDeque,
+    fmt,
     iter::{Fuse, FusedIterator},
     marker::PhantomData,
+    ops::Range,
     sync::Arc,
 };
 
@@ -36,12 +37,19 @@ pub trait WorldWritable: Send + Sync {
     fn write(self: Arc<Self>, world: &mut World, cmd: &CommandBuffer);
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
 struct InsertBufferedCommand<T> {
-    #[derivative(Debug = "ignore")]
     components: T,
     entities: Range<usize>,
+}
+
+impl<T> fmt::Debug for InsertBufferedCommand<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "InsertBufferedCommand<{}>({:?})",
+            type_name::<T>(),
+            self.entities
+        ))
+    }
 }
 
 impl<T> WorldWritable for InsertBufferedCommand<T>
@@ -125,11 +133,14 @@ impl<'a, T, A: Iterator<Item = T> + FusedIterator, B: Iterator<Item = T>> Iterat
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
 struct InsertCommand<T> {
-    #[derivative(Debug = "ignore")]
     components: T,
+}
+
+impl<T> fmt::Debug for InsertCommand<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("InsertCommand<{}>", type_name::<T>()))
+    }
 }
 
 impl<T> WorldWritable for InsertCommand<T>
@@ -142,9 +153,13 @@ where
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
 struct DeleteEntityCommand(Entity);
+
+impl fmt::Debug for DeleteEntityCommand {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("DeleteEntityCommand({:?})", self.0))
+    }
+}
 
 impl WorldWritable for DeleteEntityCommand {
     fn write(self: Arc<Self>, world: &mut World, _: &CommandBuffer) {
@@ -152,13 +167,19 @@ impl WorldWritable for DeleteEntityCommand {
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
 struct AddComponentCommand<C> {
-    #[derivative(Debug = "ignore")]
     entity: Entity,
-    #[derivative(Debug = "ignore")]
     component: C,
+}
+
+impl<T> fmt::Debug for AddComponentCommand<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "AddComponentCommand<{}>({:?})",
+            type_name::<T>(),
+            self.entity
+        ))
+    }
 }
 
 impl<C> WorldWritable for AddComponentCommand<C>
@@ -174,11 +195,19 @@ where
     }
 }
 
-#[derive(Derivative)]
-#[derivative(Debug(bound = ""))]
 struct RemoveComponentCommand<C> {
     entity: Entity,
     _marker: PhantomData<C>,
+}
+
+impl<T> fmt::Debug for RemoveComponentCommand<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!(
+            "RemoveComponentCommand<{}>({:?})",
+            type_name::<T>(),
+            self.entity
+        ))
+    }
 }
 
 impl<C> WorldWritable for RemoveComponentCommand<C>


### PR DESCRIPTION
All uses of [`derivative`](https://crates.io/crates/derivative) are trivial. Removing this dependency may slightly improve compile time.

Note: test failures due to `compare_and_swap`, which has been [deprecated](https://github.com/rust-lang/rust/pull/79261).