### PR TITLE
allow read in both subworlds within split in system

### DIFF
--- a/src/internals/permissions.rs
+++ b/src/internals/permissions.rs
@@ -164,10 +164,6 @@ impl<T: PartialEq> Permissions<T> {
 
     /// Subtracts all of the permissions contained in the given set from this permission set.
     pub fn subtract(&mut self, other: &Self) {
-        for read in other.reads_only() {
-            self.remove_read(read);
-        }
-
         for shared in other.readwrite() {
             self.remove(shared);
         }

--- a/src/internals/query/mod.rs
+++ b/src/internals/query/mod.rs
@@ -1140,7 +1140,6 @@ mod test {
         }
     }
 
-    
     #[test]
     fn complex_query_split() {
         #[derive(Debug)]

--- a/src/internals/query/mod.rs
+++ b/src/internals/query/mod.rs
@@ -1140,6 +1140,36 @@ mod test {
         }
     }
 
+    
+    #[test]
+    fn complex_query_split() {
+        #[derive(Debug)]
+        struct A;
+        #[derive(Debug)]
+        struct B;
+        #[derive(Debug)]
+        struct C;
+
+        let mut world = World::default();
+        world.push((A, B));
+        world.push((A, C));
+
+        let (_, mut world) = world.split::<&()>();
+
+        let mut query_a = <(&A, &B)>::query();
+        let mut query_b = <(&A, &mut C)>::query();
+
+        let (mut left, right) = world.split_for_query(&query_b);
+
+        for (a, c) in query_b.iter_mut(&mut left) {
+            println!("{:?} {:?}", a, c);
+
+            for (a, b) in query_a.iter(&right) {
+                println!("{:?} {:?}", a, b);
+            }
+        }
+    }
+
     #[test]
     #[should_panic]
     fn query_split_disallowd_component_left() {

--- a/src/internals/storage/group.rs
+++ b/src/internals/storage/group.rs
@@ -104,7 +104,7 @@ impl Group {
         }
     }
 
-    pub(crate) fn components<'a>(&'a self) -> impl Iterator<Item = ComponentTypeId> + 'a {
+    pub(crate) fn components(&'_ self) -> impl Iterator<Item = ComponentTypeId> + '_ {
         self.components.iter().map(|(c, _)| *c)
     }
 

--- a/src/internals/subworld.rs
+++ b/src/internals/subworld.rs
@@ -31,12 +31,10 @@ impl ArchetypeAccess {
     pub fn is_disjoint(&self, other: &ArchetypeAccess) -> bool {
         match self {
             Self::All => false,
-            Self::Some(mine) => {
-                match other {
-                    Self::All => false,
-                    Self::Some(theirs) => mine.is_disjoint(theirs),
-                }
-            }
+            Self::Some(mine) => match other {
+                Self::All => false,
+                Self::Some(theirs) => mine.is_disjoint(theirs),
+            },
         }
     }
 

--- a/src/internals/systems/system.rs
+++ b/src/internals/systems/system.rs
@@ -448,10 +448,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Resources, Schedule, internals::{
-        query::{IntoQuery},
-        systems::system::SystemBuilder,
-    }};
+    use crate::{
+        internals::{query::IntoQuery, systems::system::SystemBuilder},
+        Resources, Schedule,
+    };
 
     #[test]
     fn subworld_split_in_system_read() {
@@ -467,19 +467,17 @@ mod tests {
         world.push((Paddle, Transform));
 
         let system = SystemBuilder::new("PaddleSystem")
-        .with_query(<(&mut Ball, &Transform)>::query())
-        .with_query(<(&Paddle, &Transform)>::query())
-        .build(|_, world, _, (ball_query, paddle_query)| {
-            let (mut balls, paddles) = world.split_for_query(ball_query);
+            .with_query(<(&mut Ball, &Transform)>::query())
+            .with_query(<(&Paddle, &Transform)>::query())
+            .build(|_, world, _, (ball_query, paddle_query)| {
+                let (mut balls, paddles) = world.split_for_query(ball_query);
 
-            for _ in ball_query.iter_mut(&mut balls) {
-                for _ in paddle_query.iter(&paddles) {
+                for _ in ball_query.iter_mut(&mut balls) {
+                    for _ in paddle_query.iter(&paddles) {}
                 }
-            }
-        });
+            });
 
         let mut schedule = Schedule::builder().add_thread_local(system).build();
         schedule.execute(&mut world, &mut resources);
-
     }
 }

--- a/src/internals/systems/system.rs
+++ b/src/internals/systems/system.rs
@@ -444,3 +444,42 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Resources, Schedule, internals::{
+        query::{IntoQuery},
+        systems::system::SystemBuilder,
+    }};
+
+    #[test]
+    fn subworld_split_in_system_read() {
+        struct Ball;
+        struct Paddle;
+        struct Transform;
+
+        let mut world = World::default();
+        let mut resources = Resources::default();
+
+        world.push((Ball, Transform));
+        world.push((Paddle, Transform));
+        world.push((Paddle, Transform));
+
+        let system = SystemBuilder::new("PaddleSystem")
+        .with_query(<(&mut Ball, &Transform)>::query())
+        .with_query(<(&Paddle, &Transform)>::query())
+        .build(|_, world, _, (ball_query, paddle_query)| {
+            let (mut balls, paddles) = world.split_for_query(ball_query);
+
+            for _ in ball_query.iter_mut(&mut balls) {
+                for _ in paddle_query.iter(&paddles) {
+                }
+            }
+        });
+
+        let mut schedule = Schedule::builder().add_thread_local(system).build();
+        schedule.execute(&mut world, &mut resources);
+
+    }
+}


### PR DESCRIPTION
This function is only called when splitting a systems subworld as only system subworlds use `ComponentAccess::Allow`.

I believe that if a split includes read only access to a component then both subworlds should be able to read that component.  It would be consistent with documentation.

As of now only the left subworld gets read access to read-only components in the View.

