### PR TITLE
Allow Queries to be requested as parameters in #[system]

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -289,11 +289,13 @@ impl SystemAttr {
                 }
                 Self::new(n, s)
             }
-            Meta::NameValue(name_value) => match name_value.path.get_ident() {
-                Some(ident) if ident == "ctor" => Self::new(Some(name_value.lit.clone()), None),
-                Some(ident) => return Err(Error::InvalidKey(ident.span())),
-                _ => return Err(Error::InvalidKey(Span::call_site())),
-            },
+            Meta::NameValue(name_value) => {
+                match name_value.path.get_ident() {
+                    Some(ident) if ident == "ctor" => Self::new(Some(name_value.lit.clone()), None),
+                    Some(ident) => return Err(Error::InvalidKey(ident.span())),
+                    _ => return Err(Error::InvalidKey(Span::call_site())),
+                }
+            }
         };
 
         Ok(result)
@@ -320,124 +322,134 @@ impl Sig {
         for param in &mut item.inputs {
             match param {
                 syn::FnArg::Receiver(_) => return Err(Error::SelfNotAllowed),
-                syn::FnArg::Typed(arg) => match arg.ty.as_ref() {
-                    Type::Path(ty_path) if ty_path.path.segments[0].ident == "Option" => {
-                        let segment = &ty_path.path.segments[0];
-                        match &segment.arguments {
-                            PathArguments::AngleBracketed(bracketed) => {
-                                let arg = bracketed.args.iter().next().unwrap();
-                                match arg {
-                                    GenericArgument::Type(ty) => match ty {
-                                        Type::Reference(ty) => {
-                                            let mutable = ty.mutability.is_some();
-                                            parameters.push(Parameter::Component(query.len()));
-                                            let elem = &ty.elem;
-                                            if mutable {
-                                                query.push(parse_quote!(::legion::TryWrite<#elem>));
-                                            } else {
-                                                query.push(parse_quote!(::legion::TryRead<#elem>));
+                syn::FnArg::Typed(arg) => {
+                    match arg.ty.as_ref() {
+                        Type::Path(ty_path) if ty_path.path.segments[0].ident == "Option" => {
+                            let segment = &ty_path.path.segments[0];
+                            match &segment.arguments {
+                                PathArguments::AngleBracketed(bracketed) => {
+                                    let arg = bracketed.args.iter().next().unwrap();
+                                    match arg {
+                                        GenericArgument::Type(ty) => {
+                                            match ty {
+                                                Type::Reference(ty) => {
+                                                    let mutable = ty.mutability.is_some();
+                                                    parameters
+                                                        .push(Parameter::Component(query.len()));
+                                                    let elem = &ty.elem;
+                                                    if mutable {
+                                                        query.push(
+                                                            parse_quote!(::legion::TryWrite<#elem>),
+                                                        );
+                                                    } else {
+                                                        query.push(
+                                                            parse_quote!(::legion::TryRead<#elem>),
+                                                        );
+                                                    }
+                                                }
+                                                _ => {
+                                                    return Err(Error::InvalidOptionArgument(
+                                                        segment.ident.span(),
+                                                        quote!(#ty).to_string(),
+                                                    ))
+                                                }
                                             }
                                         }
-                                        _ => {
-                                            return Err(Error::InvalidOptionArgument(
-                                                segment.ident.span(),
-                                                quote!(#ty).to_string(),
-                                            ))
-                                        }
-                                    },
-                                    _ => panic!(),
+                                        _ => panic!(),
+                                    }
                                 }
+                                _ => panic!(),
                             }
-                            _ => panic!(),
                         }
-                    }
-                    Type::Path(ty_path)
-                        if path_match(ty_path, &["Query"])
-                            || path_match(ty_path, &["legion", "Query"])
-                            || path_match(ty_path, &["legion", "query", "Query"]) =>
-                    {
-                        return Err(Error::QueryShouldBeMutableReference(ty_path.span()));
-                    }
-                    Type::Path(ty_path) => {
-                        return Err(Error::InvalidArgument(
-                            ty_path.path.segments[0].ident.span(),
-                        ));
-                    }
-                    Type::Reference(ty)
-                        if is_type(&ty.elem, &["CommandBuffer"])
-                            || is_type(&ty.elem, &["legion", "CommandBuffer"])
-                            || is_type(&ty.elem, &["legion", "systems", "CommandBuffer"]) =>
-                    {
-                        if ty.mutability.is_some() {
-                            parameters.push(Parameter::CommandBufferMut);
-                        } else {
-                            parameters.push(Parameter::CommandBuffer);
+                        Type::Path(ty_path)
+                            if path_match(ty_path, &["Query"])
+                                || path_match(ty_path, &["legion", "Query"])
+                                || path_match(ty_path, &["legion", "query", "Query"]) =>
+                        {
+                            return Err(Error::QueryShouldBeMutableReference(ty_path.span()));
                         }
-                    }
-                    Type::Reference(ty)
-                        if is_type(&ty.elem, &["SubWorld"])
-                            || is_type(&ty.elem, &["legion", "SubWorld"])
-                            || is_type(&ty.elem, &["legion", "world", "SubWorld"]) =>
-                    {
-                        if ty.mutability.is_some() {
-                            parameters.push(Parameter::SubWorldMut);
-                        } else {
-                            parameters.push(Parameter::SubWorld);
+                        Type::Path(ty_path) => {
+                            return Err(Error::InvalidArgument(
+                                ty_path.path.segments[0].ident.span(),
+                            ));
                         }
-                    }
-                    Type::Reference(ty)
-                        if is_type(&ty.elem, &["Entity"])
-                            || is_type(&ty.elem, &["legion", "Entity"])
-                            || is_type(&ty.elem, &["legion", "world", "Entity"]) =>
-                    {
-                        parameters.push(Parameter::Component(query.len()));
-                        query.push(parse_quote!(::legion::Entity));
-                    }
-                    Type::Reference(ty)
-                        if is_type(&ty.elem, &["Query"])
-                            || is_type(&ty.elem, &["legion", "Query"])
-                            || is_type(&ty.elem, &["legion", "query", "Query"]) =>
-                    {
-                        if ty.mutability.is_none() {
-                            return Err(Error::QueryShouldBeMutableReference(ty.span()));
+                        Type::Reference(ty)
+                            if is_type(&ty.elem, &["CommandBuffer"])
+                                || is_type(&ty.elem, &["legion", "CommandBuffer"])
+                                || is_type(&ty.elem, &["legion", "systems", "CommandBuffer"]) =>
+                        {
+                            if ty.mutability.is_some() {
+                                parameters.push(Parameter::CommandBufferMut);
+                            } else {
+                                parameters.push(Parameter::CommandBuffer);
+                            }
                         }
+                        Type::Reference(ty)
+                            if is_type(&ty.elem, &["SubWorld"])
+                                || is_type(&ty.elem, &["legion", "SubWorld"])
+                                || is_type(&ty.elem, &["legion", "world", "SubWorld"]) =>
+                        {
+                            if ty.mutability.is_some() {
+                                parameters.push(Parameter::SubWorldMut);
+                            } else {
+                                parameters.push(Parameter::SubWorld);
+                            }
+                        }
+                        Type::Reference(ty)
+                            if is_type(&ty.elem, &["Entity"])
+                                || is_type(&ty.elem, &["legion", "Entity"])
+                                || is_type(&ty.elem, &["legion", "world", "Entity"]) =>
+                        {
+                            parameters.push(Parameter::Component(query.len()));
+                            query.push(parse_quote!(::legion::Entity));
+                        }
+                        Type::Reference(ty)
+                            if is_type(&ty.elem, &["Query"])
+                                || is_type(&ty.elem, &["legion", "Query"])
+                                || is_type(&ty.elem, &["legion", "query", "Query"]) =>
+                        {
+                            if ty.mutability.is_none() {
+                                return Err(Error::QueryShouldBeMutableReference(ty.span()));
+                            }
 
-                        parameters.push(Parameter::Query(ty.elem.clone()));
-                    }
-                    Type::Reference(ty) => {
-                        let mutable = ty.mutability.is_some();
-                        let attribute = Self::find_remove_arg_attr(&mut arg.attrs);
-                        match attribute {
-                            Some(ArgAttr::Resource) => {
-                                if mutable {
-                                    parameters.push(Parameter::ResourceMut(write_resources.len()));
-                                    write_resources.push(ty.elem.as_ref().clone());
-                                } else {
-                                    parameters.push(Parameter::Resource(read_resources.len()));
-                                    read_resources.push(ty.elem.as_ref().clone());
+                            parameters.push(Parameter::Query(ty.elem.clone()));
+                        }
+                        Type::Reference(ty) => {
+                            let mutable = ty.mutability.is_some();
+                            let attribute = Self::find_remove_arg_attr(&mut arg.attrs);
+                            match attribute {
+                                Some(ArgAttr::Resource) => {
+                                    if mutable {
+                                        parameters
+                                            .push(Parameter::ResourceMut(write_resources.len()));
+                                        write_resources.push(ty.elem.as_ref().clone());
+                                    } else {
+                                        parameters.push(Parameter::Resource(read_resources.len()));
+                                        read_resources.push(ty.elem.as_ref().clone());
+                                    }
                                 }
-                            }
-                            Some(ArgAttr::State) => {
-                                if mutable {
-                                    parameters.push(Parameter::StateMut(state_args.len()));
-                                } else {
-                                    parameters.push(Parameter::State(state_args.len()));
+                                Some(ArgAttr::State) => {
+                                    if mutable {
+                                        parameters.push(Parameter::StateMut(state_args.len()));
+                                    } else {
+                                        parameters.push(Parameter::State(state_args.len()));
+                                    }
+                                    state_args.push(ty.elem.as_ref().clone());
                                 }
-                                state_args.push(ty.elem.as_ref().clone());
-                            }
-                            None => {
-                                parameters.push(Parameter::Component(query.len()));
-                                let elem = &ty.elem;
-                                if mutable {
-                                    query.push(parse_quote!(::legion::Write<#elem>));
-                                } else {
-                                    query.push(parse_quote!(::legion::Read<#elem>));
+                                None => {
+                                    parameters.push(Parameter::Component(query.len()));
+                                    let elem = &ty.elem;
+                                    if mutable {
+                                        query.push(parse_quote!(::legion::Write<#elem>));
+                                    } else {
+                                        query.push(parse_quote!(::legion::Read<#elem>));
+                                    }
                                 }
                             }
                         }
+                        _ => return Err(Error::InvalidArgument(Span::call_site())),
                     }
-                    _ => return Err(Error::InvalidArgument(Span::call_site())),
-                },
+                }
             }
         }
 
@@ -787,18 +799,22 @@ impl Config {
         let world = world.unwrap_or_else(|| quote!(let for_query = world;));
         let body = match system_type {
             SystemType::Simple => fn_call,
-            SystemType::ForEach => quote! {
-                #world
-                query.for_each_mut(for_query, |components| {
-                    #fn_call
-                });
-            },
-            SystemType::ParForEach => quote! {
-                #world
-                query.par_for_each_mut(for_query, |components| {
-                    #fn_call
-                });
-            },
+            SystemType::ForEach => {
+                quote! {
+                    #world
+                    query.for_each_mut(for_query, |components| {
+                        #fn_call
+                    });
+                }
+            }
+            SystemType::ParForEach => {
+                quote! {
+                    #world
+                    query.par_for_each_mut(for_query, |components| {
+                        #fn_call
+                    });
+                }
+            }
         };
 
         // construct our system

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,8 @@ pub use legion_codegen::system;
 pub use crate::serialize::Registry;
 pub use crate::{
     query::{
-        any, component, maybe_changed, passthrough, Fetch, IntoQuery, Read, TryRead, TryWrite,
-        Write,
+        any, component, maybe_changed, passthrough, Fetch, IntoQuery, Query, Read, TryRead,
+        TryWrite, Write,
     },
     storage::{GroupSource, IntoSoa},
     systems::{Resources, Schedule, SystemBuilder},

--- a/tests/systems_basic.rs
+++ b/tests/systems_basic.rs
@@ -1,17 +1,16 @@
 #[cfg(feature = "codegen")]
 mod tests {
-    use std::fmt::Debug;
-
-    use legion::{
-        storage::Component, system, systems::CommandBuffer, world::SubWorld, IntoQuery, Query,
-        Read, Resources, Schedule, World, Write,
-    };
     use std::{
         fmt::Debug,
         sync::{
             atomic::{AtomicUsize, Ordering},
             Arc,
         },
+    };
+
+    use legion::{
+        storage::Component, system, systems::CommandBuffer, world::SubWorld, IntoQuery, Query,
+        Read, Resources, Schedule, World, Write,
     };
 
     #[test]

--- a/tests/systems_basic.rs
+++ b/tests/systems_basic.rs
@@ -3,8 +3,15 @@ mod tests {
     use std::fmt::Debug;
 
     use legion::{
-        storage::Component, system, systems::CommandBuffer, world::SubWorld, IntoQuery, Read,
-        Schedule, Write,
+        storage::Component, system, systems::CommandBuffer, world::SubWorld, IntoQuery, Query,
+        Read, Resources, Schedule, World, Write,
+    };
+    use std::{
+        fmt::Debug,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
     };
 
     #[test]
@@ -157,5 +164,44 @@ mod tests {
         fn basic<T: 'static>(#[state] _: &mut T) {}
 
         Schedule::builder().add_system(basic_system(false)).build();
+    }
+
+    #[test]
+    fn with_query() {
+        #[system]
+        fn basic(_: &mut SubWorld, _: &mut Query<(&u8, &mut i8)>) {}
+
+        Schedule::builder().add_system(basic_system()).build();
+    }
+
+    #[test]
+    fn with_two_queries() {
+        #[system]
+        fn basic(
+            #[state] a_count: &Arc<AtomicUsize>,
+            #[state] b_count: &Arc<AtomicUsize>,
+            world: &mut SubWorld,
+            a: &mut Query<(&u8, &mut usize)>,
+            b: &mut Query<(&usize, &mut bool)>,
+        ) {
+            a_count.store(a.iter_mut(world).count(), Ordering::SeqCst);
+            b_count.store(b.iter_mut(world).count(), Ordering::SeqCst);
+        }
+
+        let a_count = Arc::new(AtomicUsize::new(0));
+        let b_count = Arc::new(AtomicUsize::new(0));
+        let mut schedule = Schedule::builder()
+            .add_system(basic_system(a_count.clone(), b_count.clone()))
+            .build();
+
+        let mut world = World::default();
+        let mut resources = Resources::default();
+
+        world.extend(vec![(1_usize, false), (2_usize, false)]);
+
+        schedule.execute(&mut world, &mut resources);
+
+        assert_eq!(0, a_count.load(Ordering::SeqCst));
+        assert_eq!(2, b_count.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
This PR allows users to request queries as parameters in basic `#[system]` macro invocations. This allows a system to request multiple queries without the user having to construct them themselves. It also adds these queries to the system (via `SystemBuilder`), which means (in most cases) users won't need to use `#[read_component(T)]`/`#[write_component(T)]` attributes, and the queries persist between each run of the system, allowing for some level of caching between runs.

For example, prior to this PR:

```rust
#[system]
#[read_component(A, B)]
#[write_component(C)]
fn my_system(world: &mut SubWorld) {
    let query_a = <(&A, &mut C)>::query();
    for (a, c) in query_a.iter_mut(world) {
        ...
    }

    let query_b = <(&B, &mut C)>::query();
    for (b, c) in query_b.iter_mut(world) {
        ...
    }
}
```

Can now be written as:

```rust
#[system]
fn my_system(
    world: &mut SubWorld,
    query_a: &mut Query<(&A, &mut C)>,
    query_b: &mut Query<(&B, &mut C)>,
) {
    for (a, c) in query_a.iter_mut(world) {
        ...
    }

    for (b, c) in query_b.iter_mut(world) {
        ...
    }
}
```