### PR TITLE
Removed #[derive(Clone)] from SubWorld

### DIFF
--- a/src/internals/subworld.rs
+++ b/src/internals/subworld.rs
@@ -156,8 +156,7 @@ impl<'a> ComponentAccess<'a> {
 /// access only to the components (and mutability) declared by the view, while the right subworld
 /// will allow access to everything _but_ those components.
 ///
-/// Subworlds can be recustively further split.
-#[derive(Clone)]
+/// Subworlds can be recursively further split.
 pub struct SubWorld<'a> {
     world: &'a World,
     components: ComponentAccess<'a>,


### PR DESCRIPTION
`SubWorld` currently implements `Clone`. This was a mistake and never should have been released, but has been like this since v0.3.0.

`SubWorld` allows access rights (read/write access to certain components and certain entities) to be split, to allow one query to access some entities without borrowing the entirety of the world.

There are unsafe blocks inside both `SubWorld` and queries which assume that any mutable accesses to the world that they are allowed to perform have already been validated, which is the responsibility of the `SubWorld` and enforced by the logic of `SubWorld::split`.

Allowing the `SubWorld` to be cloned entirely invalidates this assumption, as a `SubWorld` with mutable access to a given component can be cloned and both copies will then permit aliased mutable access to that component.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
