### PR TITLE
fix: Set uuid as an optional dependency dependent of serialize feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 default = ["parallel", "serialize", "crossbeam-events", "codegen"]
 parallel = ["rayon"]
 extended-tuple-impls = []
-serialize = ["serde", "erased-serde", "uuid/serde", "scoped-tls-hkt"]
+serialize = ["serde", "erased-serde", "uuid", "uuid/serde", "scoped-tls-hkt"]
 crossbeam-events = ["crossbeam-channel"]
 codegen = ["legion_codegen"]
 stdweb = ["uuid/stdweb"]
@@ -29,7 +29,7 @@ paste = "1.0.0"
 parking_lot = "0.11"
 bit-set = "0.5"
 thiserror = "1.0"
-uuid = { version = "0.8", features = ["v4"] }
+uuid = { version = "0.8", features = ["v4"], optional = true }
 rayon = { version = "1.4", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 scoped-tls-hkt = { version = "0.1", optional = true }


### PR DESCRIPTION
## Description
The uuid crate is only needed for the serialize feature. 

## Motivation and Context
Setting the dependency to optional so it won't be compiled if one decide to disable the serialize feature. 


## Checklist:
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [X] My code is used in an example.
