### PR TITLE
Add `size_hint` implementation to entity alloc iterator

### DIFF
--- a/src/internals/entity.rs
+++ b/src/internals/entity.rs
@@ -77,6 +77,13 @@ impl<'a> Iterator for Allocate {
         self.next += 1;
         Some(entity)
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // `next()` always returns `Some`,
+        // thus naturally it's an endless iterator.
+        (usize::MAX, None)
+    }
 }
 
 /// The storage location of an entity's data.

--- a/src/internals/entity.rs
+++ b/src/internals/entity.rs
@@ -57,7 +57,7 @@ impl Default for Allocate {
     }
 }
 
-impl<'a> Iterator for Allocate {
+impl Iterator for Allocate {
     type Item = Entity;
 
     #[inline(always)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
Added `size_hint` which would improve performance of things like `Allocate::new().take(100).collect::<Vec<_>>()`.

Also removed unused lifetime, since it literally didn't do anything.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Just a little change I did while benchmarking `Allocate::next`.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The speed increase was tested in the benchmark; `Allocate::new().take(n).collect()` runs up to 75% faster, based on `n`.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
