### PR TITLE
Implement Ord for entities

### DIFF
--- a/src/internals/entity.rs
+++ b/src/internals/entity.rs
@@ -13,7 +13,7 @@ use super::{
 };
 
 /// An opaque identifier for an entity.
-#[derive(Debug, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Ord, PartialOrd, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Entity(NonZeroU64);
 


### PR DESCRIPTION
## Description
Added: Implement PartialOrd and Ord for the Entity struct
Entities are really just an integer underneath and they can be compared, so why not be ordered? Hecs, bevy and specs allows it.


## Motivation and Context
Allows entities to be used in BTreeMaps and to provide some ordering in general, it can be useful to try and be deterministic.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
