### PR TITLE
New `World::extend_out` function

### DIFF
--- a/src/internals/world.rs
+++ b/src/internals/world.rs
@@ -202,7 +202,20 @@ impl World {
     where
         Option<T>: IntoComponentSource,
     {
-        self.extend(Some(components))[0]
+        struct One(Option<Entity>);
+
+        impl<'a> Extend<&'a Entity> for One {
+            fn extend<I: IntoIterator<Item = &'a Entity>>(&mut self, iter: I) {
+                debug_assert!(self.0.is_none());
+                let mut iter = iter.into_iter();
+                self.0 = iter.next().copied();
+                debug_assert!(iter.next().is_none());
+            }
+        }
+
+        let mut o = One(None);
+        self.extend_out(Some(components), &mut o);
+        o.0.unwrap()
     }
 
     /// Appends a collection of entities to the world. Returns the IDs of the new entities.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->

Adds a new method for `World` struct.

The function extends a user-provided collection directly instead of writing to internal buffer and then giving a reference to the contents of the buffer.

Because [`Vec::extend_from_slice` simply redirects to `Vec::extend`](https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#1907), `World::extend` was changed to use `World::extend_out`; there should be no performance difference.

Also `World::push` uses `World::extend_out` to avoid allocation in `World::extend`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Mostly to allow users skip an intermediate buffer to do insertions a little bit faster.

Fixes #218.
Well, not so much of an issue fix, because the fix for the issue is really simple:

```rust
// instead of this:
let entities = world.extend(v);
// write this:
let entities = world.extend(v).to_owned();
```

but anyway, the code could also be fixed with this new function without a cost of additional allocations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

cargo test

Because `extend` and `push` use the new function, this should be enough, as every test for `push` and `extend` is also a test for `extend_out`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [x] I have added tests to cover my changes.
- [ ] My code is used in an example.
