### PR TITLE
Added add_system_boxed and add_thread_local_boxed

### DIFF
--- a/src/internals/systems/schedule.rs
+++ b/src/internals/systems/schedule.rs
@@ -425,6 +425,12 @@ impl Builder {
         self
     }
 
+    /// Adds a system to the schedule.
+    pub fn add_system_boxed(&mut self, system: Box<dyn ParallelRunnable>) -> &mut Self {
+        self.accumulator.push(system);
+        self
+    }
+
     /// Waits for executing systems to complete, and the flushes all outstanding system
     /// command buffers.
     pub fn flush(&mut self) -> &mut Self {
@@ -458,6 +464,13 @@ impl Builder {
     pub fn add_thread_local<S: Runnable + 'static>(&mut self, system: S) -> &mut Self {
         self.finalize_executor();
         let system = Box::new(system) as Box<dyn Runnable>;
+        self.steps.push(Step::ThreadLocalSystem(system));
+        self
+    }
+
+    /// Adds a thread local system to the schedule. This system will be executed on the main thread.
+    pub fn add_thread_local_boxed(&mut self, system: Box<dyn Runnable>) -> &mut Self {
+        self.finalize_executor();
         self.steps.push(Step::ThreadLocalSystem(system));
         self
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
Allow passing `Box<dyn ParallelRunnable>` and `Box<dyn Runnable>` directly.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I am storing my own systems in a `Vec<Box<dyn Runnable>>` for sorting before passing them into legion, but I cannot pass a `Box<dyn Runnable>` directly because of the explicit type requirements.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

The code passes clippy lint. I don't think testing is necessary since this is pretty straightforward.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
