### PR TITLE
Allow use of reexported legion crate for codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ crossbeam-events = ["crossbeam-channel"]
 codegen = ["legion_codegen"]
 stdweb = ["uuid/stdweb"]
 wasm-bindgen = ["uuid/wasm-bindgen"]
+reexport = ["legion_codegen", "legion_codegen/reexport"]
 
 [dependencies]
 legion_codegen = { path = "codegen", version = "0.4.0", optional = true }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -18,3 +18,7 @@ quote = "1.0"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = "1.0"
 thiserror = "1.0"
+
+[features]
+default = []
+reexport = []

--- a/tests/failures/par_mut_command.stderr
+++ b/tests/failures/par_mut_command.stderr
@@ -4,4 +4,4 @@ error: par_for_each systems cannot accept mutable command buffer references
 5 | #[system(par_for_each)]
   | ^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `system` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/failures/par_mut_resource.stderr
+++ b/tests/failures/par_mut_resource.stderr
@@ -4,4 +4,4 @@ error: par_for_each systems cannot accept mutable resource references
 5 | #[system(par_for_each)]
   | ^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `system` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/failures/par_mut_world.stderr
+++ b/tests/failures/par_mut_world.stderr
@@ -4,4 +4,4 @@ error: par_for_each systems cannot accept mutable world references
 5 | #[system(par_for_each)]
   | ^^^^^^^^^^^^^^^^^^^^^^^
   |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the attribute macro `system` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## Description
If a crate uses legion and wants to reexport it, it works for all
functionality except the codegen.

Using the :: prefix forces the dependency to exist as a crate for calling
project - which in turn forces the user of the third-party crate to keep
legion in their own Cargo.toml and make sure the versions match over
time.


## Motivation and Context
If a crate uses legion and wants to reexport it, it works for all
functionality except the codegen.

Using the :: prefix forces the dependency to exist as a crate for calling
project - which in turn forces the user of the third-party crate to keep
legion in their own Cargo.toml and make sure the versions match over
time.


## How Has This Been Tested?
This has been tested by compiling the Amethyst `sampler_interpolation` system with the feature flag and without the extra dependency.


## Checklist:
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
