### PR TITLE
Fix bug wrong macro expansion order for reexport feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ codegen = ["legion_codegen"]
 stdweb = ["uuid/stdweb"]
 wasm-bindgen = ["uuid/wasm-bindgen"]
 reexport = ["legion_codegen", "legion_codegen/reexport"]
+no-reexport = ["legion_codegen/no-reexport"]
 
 [dependencies]
 legion_codegen = { path = "codegen", version = "0.4.0", optional = true }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -22,3 +22,4 @@ thiserror = "1.0"
 [features]
 default = []
 reexport = []
+no-reexport = []

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -321,10 +321,9 @@ impl Sig {
         let mut state_args = Vec::new();
 
         // Don't enable for tests or benchmarks
-        let prefix = match env!("CARGO_PKG_NAME") != "legion" && cfg!(reexport) {
-            true => quote!(self),
-            false => quote!(),
-        };
+        let prefix = quote!();
+        #[cfg(all(feature = "reexport", not(feature = "no-reexport")))]
+        let prefix = quote!(self);
 
         for param in &mut item.inputs {
             match param {
@@ -844,10 +843,9 @@ impl Config {
         let write_resources = &signature.write_resources;
 
         // Don't enable for tests or benchmarks
-        let prefix = match env!("CARGO_PKG_NAME") != "legion" && cfg!(reexport) {
-            true => quote!(self),
-            false => quote!(),
-        };
+        let prefix = quote!();
+        #[cfg(all(feature = "reexport", not(feature = "no-reexport")))]
+        let prefix = quote!(self);
 
         let builder = quote! {
             use legion::IntoQuery;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
The reexport feature doesn't work because the cfg! macro is expanded in the caller code.
This means that the feature is only enabled if the calling crate has a feature called "reexport", and not if that feature is enabled in the legion crate.

Using `#[cfg(...)]` makes the feature check happen at legion_codegen's compile-time, which fixes the above issue.

The biggest challenge with this change is to get around the tests. The automated tests run with `--all-features`, which enables the `reexport` feature for the tests which then fail. By adding two features which must not be enabled at the same time, we can get around this issue.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix is necessary for the feature to work as intended.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This has been tested in a local setup with amethyst using legion as a local dependency with this change.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [x] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
