### PR TITLE
Update readme with missing feature flag.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Legion provides a few feature flags:
 * `extended-tuple-impls` - Extends the maximum size of view and component tuples from 8 to 24, at the cost of increased compile times. Off by default.
 * `serialize` - Enables the serde serialization module and associated functionality. Enabled by default.
 * `crossbeam-events` - Implements the `EventSender` trait for crossbeam `Sender` channels, allowing them to be used for event subscriptions. Enabled by default.
+* `codegen` - Enables the `#[system]` procedural macro. Enabled by default.
 
 ## WASM
 


### PR DESCRIPTION
The readme file is missing the codegen feature flag.

## Description

I just added the missing feature flag.

## Motivation and Context

If you read the readme and tray to use the lib in a wasm project, the build is going to fail, and you are not going to know why.

## How Has This Been Tested?

It displays correctly in the GitHub README.

## Checklist:
- [X] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [X] My code follows the code style of this project.
- [ ] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
