### PR TITLE
Implement LayoutFilter for Box<dyn LayoutFilter + Send>

### DIFF
--- a/src/internals/query/filter/mod.rs
+++ b/src/internals/query/filter/mod.rs
@@ -113,7 +113,7 @@ pub trait LayoutFilter {
     fn matches_layout(&self, components: &[ComponentTypeId]) -> FilterResult;
 }
 
-impl LayoutFilter for Box<dyn LayoutFilter> {
+impl LayoutFilter for Box<dyn LayoutFilter + Send> {
     fn matches_layout(&self, components: &[ComponentTypeId]) -> FilterResult {
         self.as_ref().matches_layout(components)
     }

--- a/src/internals/query/filter/mod.rs
+++ b/src/internals/query/filter/mod.rs
@@ -155,6 +155,23 @@ pub trait EntityFilter: Default + Send + Sync {
     fn filters(&mut self) -> (&Self::Layout, &mut Self::Dynamic);
 }
 
+impl<T, L, D> EntityFilter for Box<T>
+    where T: EntityFilter<Layout=L, Dynamic=D>,
+          L: LayoutFilter + GroupMatcher + Default + Send + Sync,
+          D: DynamicFilter
+{
+    type Layout = L;
+    type Dynamic = D;
+
+    fn layout_filter(&self) -> &Self::Layout {
+        self.as_ref().layout_filter()
+    }
+
+    fn filters(&mut self) -> (&Self::Layout, &mut Self::Dynamic) {
+        self.as_mut().filters()
+    }
+}
+
 impl<T: EntityFilter> LayoutFilter for T {
     fn matches_layout(&self, components: &[ComponentTypeId]) -> FilterResult {
         self.layout_filter().matches_layout(components)

--- a/src/internals/query/filter/mod.rs
+++ b/src/internals/query/filter/mod.rs
@@ -113,6 +113,12 @@ pub trait LayoutFilter {
     fn matches_layout(&self, components: &[ComponentTypeId]) -> FilterResult;
 }
 
+impl LayoutFilter for Box<dyn LayoutFilter> {
+    fn matches_layout(&self, components: &[ComponentTypeId]) -> FilterResult {
+        self.as_ref().matches_layout(components)
+    }
+}
+
 /// A filter which selects based upon the data available in the archetype.
 pub trait DynamicFilter: Default + Send + Sync {
     /// Prepares the filter to run.

--- a/src/internals/query/filter/mod.rs
+++ b/src/internals/query/filter/mod.rs
@@ -155,23 +155,6 @@ pub trait EntityFilter: Default + Send + Sync {
     fn filters(&mut self) -> (&Self::Layout, &mut Self::Dynamic);
 }
 
-impl<T, L, D> EntityFilter for Box<T>
-    where T: EntityFilter<Layout=L, Dynamic=D>,
-          L: LayoutFilter + GroupMatcher + Default + Send + Sync,
-          D: DynamicFilter
-{
-    type Layout = L;
-    type Dynamic = D;
-
-    fn layout_filter(&self) -> &Self::Layout {
-        self.as_ref().layout_filter()
-    }
-
-    fn filters(&mut self) -> (&Self::Layout, &mut Self::Dynamic) {
-        self.as_mut().filters()
-    }
-}
-
 impl<T: EntityFilter> LayoutFilter for T {
     fn matches_layout(&self, components: &[ComponentTypeId]) -> FilterResult {
         self.layout_filter().matches_layout(components)

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -65,18 +65,15 @@
 //! // store serialization requests with different entity filters together
 //! let serialize_requests: Vec<(&str, Box<dyn LayoutFilter + Send>)> = vec![
 //!     ("all entities", Box::new(any())),
-//!     ("entities having names", Box::new(component::<Name>())),
-//!     ("entities without velocity", Box::new(!component::<Velocity>())),
+//!     ("having names", Box::new(component::<Name>())),
+//!     ("without velocity", Box::new(!component::<Velocity>())),
 //! ];
 //!
 //! // process all requests
 //! for (title, filter) in serialize_requests {
-//!     let json = serde_json::to_value(&world.as_serializable(
-//!         filter,
-//!         &registry,
-//!         &entity_serializer,
-//!     ))
-//!     .unwrap();
+//!     let json =
+//!         serde_json::to_value(&world.as_serializable(filter, &registry, &entity_serializer))
+//!             .unwrap();
 //!     println!("{}: {:#}", title, json);
 //! }
 //!

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -76,7 +76,6 @@
 //!             .unwrap();
 //!     println!("{}: {:#}", title, json);
 //! }
-//!
 //! ```
 //!
 //! ## Why also `Send`?


### PR DESCRIPTION
Added implementation of the `LayoutFilter` trait for `Box<dyn LayoutFilter + Send>`.

## Description
<!--- Describe your changes in detail -->
<!--- Separate Additions, Removals and Modifications -->
- Added `impl LayoutFilter for Box<dyn LayoutFilter + Send> {...}`.
- Corresponding documentation entry added with an example and motivation explanations.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When serializing a `World`, world- and entity serializers are passed to `World::as_serializable()` by reference while the layout filter is passed by value - even though `LayoutFilter::matches_layout()` does not consume the filter object. Because of that, when a user tried to develop a solution that will allow systems to request world serialization (that should be performed outside the `Schedule` since systems do not have access to the whole `World` to do that) there was no way to store the desired layout filter in any type-agnostic way.

This change allows storing layout filters inside `Box`es and later passing them "as is" to `World::as_serializable()` without breaking the existing interface.
In particular, this change solves the problem of decoupling the code that requests world serialization from the code that actually performs it, including the layout filter type. So now it's possible for different systems to store serialization requests (including custom layout filters) in `Resources` that will later be processed altogether outside the `Schedule` execution.

An additional `Send` requirement was added to allow to store filters in `Resources` accessed by systems that don't have to be thread-local.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've tested these changes in my private project, but I've also added a corresponding example to the documentation (that, I suppose, could count as a doc-test).


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [x] My code is used in an example.
