### PR TITLE
Make KnownLength public

### DIFF
--- a/src/internals/insert.rs
+++ b/src/internals/insert.rs
@@ -220,7 +220,13 @@ pub trait ComponentSource: ArchetypeSource {
 
 /// A collection with a known length.
 pub trait KnownLength {
+    /// Gets the length of the collection.
     fn len(&self) -> usize;
+
+    /// Returns true only if the collection is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 /// Converts a type into a [`ComponentSource`].

--- a/src/internals/permissions.rs
+++ b/src/internals/permissions.rs
@@ -265,11 +265,10 @@ impl<T: PartialEq> Default for Permissions<T> {
 impl<T: PartialEq + Debug> Debug for Permissions<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fn list<V: Debug>(items: &[V]) -> String {
-            use itertools::Itertools;
             items
                 .iter()
                 .map(|x| format!("{:?}", x))
-                .fold1(|x, y| format!("{}, {}", x, y))
+                .reduce(|x, y| format!("{}, {}", x, y))
                 .unwrap_or_else(|| "".to_owned())
         }
 
@@ -285,11 +284,10 @@ impl<T: PartialEq + Debug> Debug for Permissions<T> {
 impl<T: PartialEq + Display> Display for Permissions<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fn list<V: Display>(items: &[V]) -> String {
-            use itertools::Itertools;
             items
                 .iter()
                 .map(|x| format!("{}", x))
-                .fold1(|x, y| format!("{}, {}", x, y))
+                .reduce(|x, y| format!("{}, {}", x, y))
                 .unwrap_or_else(|| "".to_owned())
         }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -81,7 +81,7 @@ pub use crate::internals::{
     hash::{ComponentTypeIdHasher, U64Hasher},
     insert::{
         ArchetypeSource, ArchetypeWriter, ComponentSource, ComponentWriter, IntoComponentSource,
-        IntoSoa, UnknownComponentWriter,
+        IntoSoa, KnownLength, UnknownComponentWriter,
     },
     storage::{
         archetype::{Archetype, ArchetypeIndex, EntityLayout},


### PR DESCRIPTION
- Make the `KnownLength` trait public as `legion::storage::KnownLength`.
- Fix lints and use `Iterator::reduce` instead of the deprecated [`Itertools::fold1`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.fold1).



## Motivation and Context
Closes issue https://github.com/amethyst/legion/issues/274

[CommandBuffer](https://docs.rs/legion/0.4.0/legion/systems/struct.CommandBuffer.html#method.push) allows to push components for a new entity, but its signature constraints the `components` arguments with several traits. One of this is `KownLength` which at the moment is private. This unfortunately prevents from defining systems which take generic arguments as input that can be then used to create the entity components with `CommandBuffer.

For example, in my specific case I am in a situation where I'd like to be able to do something like the following:

```rust
#[system]
fn clone<EntityBuilder, Components>(cmd: &mut CommandBuffer)
where
    EntityBuilder: MyBuilderTrait<Components = Components> + Sync,
    Option<Components>: IntoComponentSource + 'static,
    <Option<Components> as IntoComponentSource>::Source: Send + Sync + KnownLength,
{
     let builder = EntityBuilder::new(...);
     let components = builder.build();

     cmd.push(components);
}
```




## How Has This Been Tested?
Running `cargo test` on this branch is successful.



## Checklist:
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [ ] My code follows the code style of this project.
- [x] If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] I have updated the content of the book if this PR would make the book outdated.
- [ ] I have added tests to cover my changes.
- [ ] My code is used in an example.
