### PR TITLE
A bit better diagnostic on EntityAccessDenied.

### DIFF
--- a/src/internals/subworld.rs
+++ b/src/internals/subworld.rs
@@ -1,5 +1,6 @@
 //! Contains types related to the [`SubWorld`] which can split a world by component type access.
 
+use std::any::type_name;
 use std::borrow::Cow;
 
 use bit_set::BitSet;
@@ -256,6 +257,8 @@ impl<'a> EntityStore for SubWorld<'a> {
                 .unwrap()
                 .with_allowed_archetypes(self.archetypes))
         } else {
+            // It's unwrap()ed on every path anyway.
+            // println!("invalid view access: {}", type_name::<V>());
             Err(EntityAccessError::AccessDenied)
         }
     }


### PR DESCRIPTION


## Description

## Motivation and Context
Currently, all calls to `get_component_storage()` are just `unwrap()`ed.

This is clearly a temporary code that, unfortunately, is staying with us.

With this change, at least, the user gets a list of types that the calling System needed access to. Currently, it's anybody's guess, and in a deep call trees, it's difficult to see.


## How Has This Been Tested?

I removed access to a necessary Component in one of my Systems, and instead of generic unwrap() panic, got a message:

```
EntityAccessDenied for view: (&macroquad_tiled_redux::map_point::MapPoint, &stepsonsrl::mob::Mob, core::option::Option<&stepsonsrl::mob::interaction::Interactable>, &stepsons_buffdebuff::ecs::components::HitPoints, legion::internals::entity::Entity): AccessDenied
```

Now I know which Components to add to my System.

## Checklist:
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.
- [x] My code follows the code style of this project.
- [ ] n/a If my change required a change to the documentation I have updated the documentation accordingly.
- [ ] n/a I have updated the content of the book if this PR would make the book outdated.
- [ ] n/a I have added tests to cover my changes.
- [ ] n/a My code is used in an example.
